### PR TITLE
Fix CSV field name for Watts per vCPU

### DIFF
--- a/backend/app/services/catalogue_sync.py
+++ b/backend/app/services/catalogue_sync.py
@@ -15,7 +15,7 @@ async def sync_skus(db: AsyncSession):
             provider="aws",
             vcpu=int(row["vCPU"]),
             ram_gb=float(row["MemoryGiB"]),
-            watts_per_vcpu=float(row["WattsPervCPU"]),
+            watts_per_vcpu=float(row["WattsPerVCPU"]),
             price_hour_usd=float(row["OnDemandUSD"]),
         )
         if sku:


### PR DESCRIPTION
## Summary
- fix WattsPerVCPU column name when reading the SKU dataset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette.middleware.secure_headers')*

------
https://chatgpt.com/codex/tasks/task_e_6840a583d7388322893c627354d74525