### PR TITLE
Add secure headers middleware

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -9,7 +9,7 @@ from .settings import get_settings
 settings = get_settings()
 
 # 1 engine ──────────────────────────────────
-engine: AsyncEngine = create_async_engine(settings.database_url, echo=False, future=True)
+engine: AsyncEngine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
 
 # 2 session factory ─────────────────────────
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_pagination import add_pagination
 from prometheus_fastapi_instrumentator import Instrumentator
-from starlette.middleware.secure_headers import SecureHeadersMiddleware
+from app.middleware.secure_headers import SecureHeadersMiddleware
 import structlog
 
 from .core.deps import init_db, engine

--- a/backend/app/middleware/secure_headers.py
+++ b/backend/app/middleware/secure_headers.py
@@ -1,0 +1,19 @@
+from secure import Secure
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+class SecureHeadersMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        # use sane defaults for common security headers
+        self.secure = Secure.with_default_headers()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: dict) -> None:
+            if message["type"] == "http.response.start":
+                for name, value in self.secure.headers.items():
+                    message.setdefault("headers", []).append(
+                        (name.encode(), value.encode())
+                    )
+            await send(message)
+        await self.app(scope, receive, send_wrapper)
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ passlib = {extras = ["bcrypt"], version = "^1.7.4"}
 celery = {extras = ["redis"], version = "^5.3.6"}
 python-dotenv = "^1.0.1"
 pydantic-settings = "^2.3.2"
+secure = "^1.0.1"
 greenlet = "^3.2.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/backend/tests/test_secure_headers.py
+++ b/backend/tests/test_secure_headers.py
@@ -1,0 +1,23 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from app.middleware.secure_headers import SecureHeadersMiddleware
+
+pytestmark = pytest.mark.anyio
+
+async def test_secure_headers_applied():
+    app = FastAPI()
+    app.add_middleware(SecureHeadersMiddleware)
+
+    @app.get("/")
+    async def root():
+        return {"msg": "ok"}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/")
+
+    assert r.status_code == 200
+    assert "X-Frame-Options" in r.headers
+    assert r.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary
- add `secure` dependency
- implement custom `SecureHeadersMiddleware`
- wire middleware in main FastAPI app
- fix database settings reference
- test middleware headers

## Testing
- `PYTHONPATH=backend pytest -q backend/tests/test_secure_headers.py` *(fails: cannot import name 'limiter' from slowapi)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad883548832298c4c17e8e4f9c55