### PR TITLE
Fix Trivy workflow version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           poetry run pytest -q
 
       - name: Trivy SBOM & vuln scan
-        uses: aquasecurity/trivy-action@v0.22.0
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           image-ref: ghcr.io/${{ github.repository }}/carboncore-backend:latest
           format: table


### PR DESCRIPTION
## Summary
- correct the aquasecurity/trivy-action reference in CI workflow

## Testing
- `poetry run ruff .` *(fails: Failed to parse events.py)*
- `poetry run mypy .` *(fails: parameter without a default)*
- `PYTHONPATH=. poetry run pytest -q` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6840b2115d64832297f9e54575256f81