### PR TITLE
Fix imports and remove invalid dependency

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,9 +25,6 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from app.middleware.secure_headers import SecureHeadersMiddleware
 import structlog
 
-# ← Replace SecureHeadersMiddleware import with SecureHeaders
-from secure import SecureHeaders
-
 from .core.deps import init_db, engine
 from .core.logging import init_logging
 from .core.otel import init_otel
@@ -51,13 +48,13 @@ async def lifespan(_: FastAPI):
 # ──────────────── middleware list ──────────────────────────────
 MIDDLEWARE: Final = []
 if getattr(settings, "SECURE_HEADERS", True):
-    # Use `SecureHeaders` directly (it acts as ASGI middleware)
-    MIDDLEWARE.append({"middleware_class": SecureHeaders})
+    # Apply Secure headers via custom Starlette middleware
+    MIDDLEWARE.append({"middleware_class": SecureHeadersMiddleware})
 
 # ──────────────── FastAPI factory ──────────────────────────────
 app = FastAPI(
     title="CarbonCore API",
-    version=getattr(settings, "BUILD_SHA", "0.1.0-beta.1"),
+    version=getattr(settings, "BUILD_SHA", None) or "0.1.0-beta.1",
     docs_url="/",
     redoc_url=None,
     root_path=f"/{settings.BLUE_GREEN_COLOR}" if getattr(settings, "BLUE_GREEN_COLOR", "") else "",

--- a/backend/app/routers/carbon.py
+++ b/backend/app/routers/carbon.py
@@ -22,7 +22,7 @@ from datetime import datetime
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from prometheus_client import Counter, Histogram
-from slowapi import limiter
+from ..core.ratelimit import limiter
 
 from ..services.carbon_feed import fetch_intensity
 from .tokens import verify_project_token, ProjectToken  # auth dependency

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -29,6 +29,7 @@ from fastapi import (
     Request,
     status,
 )
+from typing import Annotated
 from fastapi_pagination import Page, Params, paginate
 from prometheus_client import Counter, Histogram
 from sqlmodel import select
@@ -110,8 +111,8 @@ async def create_event(
 @router.post("/batch", status_code=status.HTTP_202_ACCEPTED)
 @limiter.limit("60/minute")
 async def batch_events(
-    payload: List[SavingEvent] = Body(..., description="≤ 5 000 SavingEvent objects"),
     request: Request,  # noqa: D401
+    payload: List[SavingEvent] = Body(..., description="≤ 5 000 SavingEvent objects"),
     db: AsyncSession = Depends(get_db),
     _: ProjectToken = Depends(verify_project_token),
 ):
@@ -147,7 +148,7 @@ async def batch_events(
 @limiter.limit("120/minute")
 async def list_events(
     request: Request,  # noqa: D401
-    params: Params = Depends(),
+    params: Annotated[Params, Depends()],
     project_id: UUID | None = Query(None),
     feature: str | None = Query(None),
     since: datetime | None = Query(None),

--- a/backend/app/routers/skus.py
+++ b/backend/app/routers/skus.py
@@ -25,9 +25,10 @@ from fastapi import (
     Request,
     status,
 )
+from typing import Annotated
 from fastapi_pagination import Page, Params, paginate
 from prometheus_client import Counter
-from slowapi import limiter
+from ..core.ratelimit import limiter
 from sqlmodel import asc, desc, or_, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -58,7 +59,7 @@ def _order_clause(col: str, direction: str):
 @limiter.limit("120/minute")
 async def list_skus(
     request: Request,                         # noqa: D401
-    params: Params = Depends(),
+    params: Annotated[Params, Depends()],
     provider: str | None = Query(None),
     q: str | None = Query(
         None,

--- a/backend/app/routers/tokens.py
+++ b/backend/app/routers/tokens.py
@@ -31,6 +31,7 @@ from fastapi import (
     Request,
     status,
 )
+from typing import Annotated
 from fastapi_pagination import Page, Params, paginate
 from passlib.hash import bcrypt
 from prometheus_client import Counter
@@ -103,7 +104,7 @@ async def create_token(
 @limiter.limit("60/minute")
 async def list_tokens(
     request: Request,                     # noqa: D401
-    params: Params = Depends(),
+    params: Annotated[Params, Depends()],
     db: AsyncSession = Depends(get_db),
     _: ProjectToken = Depends(verify_project_token),
 ):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,11 +36,8 @@ greenlet = "^3.2.2"
 # Caching
 redis = { extras = ["hiredis"], version = "^5.0.4" }
 
-# ❌ remove this line:
-# secure = "^0.3.0"
 
 # Security headers middleware (Starlette‐compatible)
-starlette-secureheaders = "^0.4.0"
 
 # ───────────────────────────── Observability ─────────────────────────────
 prometheus-client                    = "^0.20.0"


### PR DESCRIPTION
## Summary
- drop nonexistent `starlette-secureheaders` from backend deps
- default to local SecureHeaders middleware
- fix failing router imports
- use `Annotated[Params, Depends()]` for pagination
- ensure FastAPI version string is always set

## Testing
- `pytest -q` *(fails: Event loop is closed; ModuleNotFoundError: No module named 'trio')*

------
https://chatgpt.com/codex/tasks/task_e_6840b7cd3aec8322965a8faf1dd6cc0b