### PR TITLE
Fix missing OTEL instrumentation dependencies

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -46,6 +46,8 @@ opentelemetry-api                    = "^1.24.0"
 opentelemetry-sdk                    = "^1.24.0"
 opentelemetry-exporter-otlp          = "^1.24.0"
 opentelemetry-instrumentation-fastapi = { version = "0.48b0", allow-prereleases = true }
+opentelemetry-instrumentation-httpx  = "^0.48b0"
+opentelemetry-instrumentation-sqlalchemy = "^0.48b0"
 
 # ───────────────────────────── Dev / CI ────────────────────────────
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- add opentelemetry-instrumentation-httpx and sqlalchemy

## Testing
- `poetry install` *(fails: asyncpg build error)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0dac4408322b48c775d1d464b34