### PR TITLE
Fix Celery redis URL lookup

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -22,6 +22,11 @@ class Settings(BaseSettings):
         "postgresql+asyncpg://postgres:postgres@db:5432/carboncore"
     )
     REDIS_URL: str = "redis://redis:6379/0"
+
+    @property
+    def redis_url(self) -> str:  # noqa: N802
+        """Alias for Celery configuration."""
+        return self.REDIS_URL
     OTEL_EXPORTER_OTLP_ENDPOINT: str | None = None       # e.g. http://tempo:4318
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
     RATE_LIMIT: str = "30/second"                        # global slowapi default


### PR DESCRIPTION
## Summary
- expose `redis_url` property on `Settings`

## Testing
- `poetry run ruff check .` *(fails: failed to parse celeryconfig.py)*
- `poetry run mypy app` *(fails: found 43 errors)*
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e4f692c083229a877897176af02d