### PR TITLE
Disable OTEL exporter locally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/carboncore
       REDIS_URL: redis://redis:6379/0
+      OTEL_TRACES_EXPORTER: none
     depends_on: [db, redis]
     ports: ["8000:8000"]
 
@@ -35,4 +36,5 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/carboncore
       REDIS_URL: redis://redis:6379/0
+      OTEL_TRACES_EXPORTER: none
     depends_on: [backend, redis]


### PR DESCRIPTION
## Summary
- stop noisy OTEL trace exporter when running the dev stack

## Testing
- `poetry run ruff .` *(fails: missing closing quote in celeryconfig.py)*
- `poetry run mypy .` *(fails: unterminated string literal in celeryconfig.py)*
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e824bfbc83229fd1fb11ae2d39cb