### PR TITLE
Implement offline stubs and health limiter

### DIFF
--- a/backend/app/core/ratelimit.py
+++ b/backend/app/core/ratelimit.py
@@ -2,7 +2,9 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
-limiter: Limiter = Limiter(key_func=get_remote_address)
+limiter: Limiter = Limiter(
+    key_func=get_remote_address, default_limits=["20/second"]
+)
 
 
 def attach(app) -> None:


### PR DESCRIPTION
## Summary
- avoid hitting live ElectricityMaps during tests by stubbing `fetch_intensity`
- add rate limiting to `/healthz` endpoint
- configure default limiter burst

## Testing
- `poetry run pytest -q` *(fails: test_carbon_bad_zone - assert 200 == 400)*

------
https://chatgpt.com/codex/tasks/task_e_6843d81605488322b6469cd5ba0d08bc