### PR TITLE
Apply stub feed and tweak rate limit

### DIFF
--- a/backend/app/core/ratelimit.py
+++ b/backend/app/core/ratelimit.py
@@ -3,7 +3,7 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
 limiter: Limiter = Limiter(
-    key_func=get_remote_address, default_limits=["20/second"]
+    key_func=get_remote_address, default_limits=["5/second"]
 )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,7 +83,7 @@ add_pagination(app)
 
 # Health / readiness probes
 @app.get("/healthz", include_in_schema=False)
-@limiter.limit("20/second")
+@limiter.limit("5/second")
 async def healthz(request: Request) -> dict[str, str]:
     return {"status": "ok", "ts": datetime.utcnow().isoformat()}
 

--- a/backend/app/services/_test_stub.py
+++ b/backend/app/services/_test_stub.py
@@ -1,0 +1,6 @@
+from typing import Final
+STUB_GCO2: Final = 406  # deterministic value for tests/CI
+
+async def fetch_intensity(_: str) -> int:  # noqa: D401
+    """Offline stub used whenever live tokens are absent."""
+    return STUB_GCO2

--- a/backend/app/services/carbon_feed.py
+++ b/backend/app/services/carbon_feed.py
@@ -15,6 +15,8 @@ import asyncio
 from abc import ABC, abstractmethod
 from typing import Callable, Final
 import os
+import importlib
+import sys
 
 import httpx
 import redis.asyncio as redis
@@ -153,6 +155,10 @@ class WattTimeAdapter(BaseAdapter):
 
 # ───────────────────── Provider registry & API ──────────────────────────
 TOKEN = os.getenv("ELECTRICITYMAPS_TOKEN")
+if TOKEN in (None, "", "dummy-token"):
+    sys.modules[__name__].fetch_intensity = importlib.import_module(
+        "app.services._test_stub"
+    ).fetch_intensity
 
 # ------------------------------------------------------------
 # In CI or when TOKEN is a dummy value we don't want to hit the


### PR DESCRIPTION
## Summary
- stub out the carbon feed via `_test_stub` when dummy creds are used
- limit `/healthz` endpoint to 5 requests per second
- reduce global rate limit default to 5 requests per second

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `poetry install -n` *(fails: asyncpg build error)*

------
https://chatgpt.com/codex/tasks/task_e_6843ddd5651c83228160368de642c0b8