### PR TITLE
Fix self-contained tests and rate limiter reset

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -55,6 +55,7 @@ carbon_router.carbon_intensity = carbon_router.limiter.limit("30/minute")(carbon
 @pytest_asyncio.fixture
 async def client():
     """Reusable async HTTP client bound to the FastAPI app."""
+    carbon_router.limiter.reset()
     await init_db()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,26 +1,22 @@
 # tests/test_api.py
-import httpx, pytest, asyncio, os
+import pytest, asyncio
 
-BASE = "http://localhost:8000"
-HDR  = {"x-project-token": "demo"}
+HDR = {"x-project-token": "demo"}
 
 @pytest.mark.asyncio
-async def test_ae_ok():
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f"{BASE}/carbon?zone=AE", headers=HDR)
+async def test_ae_ok(client):
+    r = await client.get("/carbon?zone=AE", headers=HDR)
     assert r.status_code == 200
     j = r.json()
     assert j["zone"] == "AE" and j["gco2_per_kwh"] > 0
 
 @pytest.mark.asyncio
-async def test_missing_zone():
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f"{BASE}/carbon", headers=HDR)
+async def test_missing_zone(client):
+    r = await client.get("/carbon", headers=HDR)
     assert r.status_code == 422
 
 @pytest.mark.asyncio
-async def test_rate_limit():
-    async with httpx.AsyncClient() as c:
-        tasks = [c.get(f"{BASE}/healthz", headers=HDR) for _ in range(40)]
-        rs = await asyncio.gather(*tasks)
+async def test_rate_limit(client):
+    tasks = [client.get("/healthz", headers=HDR) for _ in range(40)]
+    rs = await asyncio.gather(*tasks)
     assert any(r.status_code == 429 for r in rs)

--- a/backend/tests/test_carbon.py
+++ b/backend/tests/test_carbon.py
@@ -1,19 +1,16 @@
 # tests/test_carbon.py
-import httpx, pytest, asyncio
+import pytest
 
-BASE = "http://localhost:8000"
-HDR  = {"x-project-token": "demo"}
+HDR = {"x-project-token": "demo"}
 
 @pytest.mark.asyncio
-async def test_carbon_ok():
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f"{BASE}/carbon?zone=AE", headers=HDR)
+async def test_carbon_ok(client):
+    r = await client.get("/carbon?zone=AE", headers=HDR)
     j = r.json()
     assert r.status_code == 200
     assert "gco2_per_kwh" in j and j["gco2_per_kwh"] > 0
 
 @pytest.mark.asyncio
-async def test_carbon_bad_zone():
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f"{BASE}/carbon?zone=ZZZ", headers=HDR)
+async def test_carbon_bad_zone(client):
+    r = await client.get("/carbon?zone=ZZZ", headers=HDR)
     assert r.status_code == 400


### PR DESCRIPTION
## Summary
- update tests to use in-app client rather than external HTTP
- reset rate limits between tests to avoid state leakage

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fc1b442c8322bb1e45cadf2e2962