### PR TITLE
Fix pydantic model rebuilding for SQLModel tables

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -97,3 +97,11 @@ class ProjectToken(SQLModel, table=True):
     @staticmethod
     def verify(raw: str, hashed: str) -> bool:  # noqa: D401
         return bcrypt.verify(raw, hashed)
+
+
+# ─────────────────── Model rebuilds ───────────────────────────
+for _model in (Sku, CarbonSnapshot, EventType, SavingEvent, ProjectToken):
+    try:  # Pydantic v2
+        _model.model_rebuild()
+    except AttributeError:  # v1 fallback
+        _model.update_forward_refs()


### PR DESCRIPTION
## Summary
- call `model_rebuild` or `update_forward_refs` for all SQLModel tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684a0a03a5d08322b3b5f026e5925744