### PR TITLE
Fix plugin routes & rebuild registry

### DIFF
--- a/backend/app/plugin_manifest.py
+++ b/backend/app/plugin_manifest.py
@@ -1,6 +1,7 @@
 # backend/app/plugin_manifest.py
 from pydantic import BaseModel
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
+from fastapi import APIRouter
 
 class Route(BaseModel):
     handler: str                         # dotted path  "backend.app.routers.skus:router"
@@ -12,4 +13,7 @@ class PluginManifest(BaseModel):
     id: str
     version: str = "0.1.0"
     tasks: List[str] = []
-    routes: List[Route] = []            # ← new
+    routes: List[Union[APIRouter, Route]] = []            # ← new
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -1,8 +1,2 @@
-from app.plugin_manifest import PluginManifest, Route
-
-REGISTRY: dict[str, PluginManifest] = {
-    "core": PluginManifest(**{'id': 'core', 'event_types': [], 'routes': [{'handler': 'app.routers.skus:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'app.routers.carbon:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'app.routers.events:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'app.routers.tokens:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'schedules': []}),
-}
-
-registry = REGISTRY  # FastAPI alias
-__all__ = ['REGISTRY', 'registry']
+from app.schemas.plugins import PluginManifest, Route
+registry =  [PluginManifest(id='core', event_types=[], routes=[<fastapi.routing.APIRouter object at 0x7f6b78b46e90>, <fastapi.routing.APIRouter object at 0x7f6b733badd0>, <fastapi.routing.APIRouter object at 0x7f6b733baa90>, <fastapi.routing.APIRouter object at 0x7f6b73320a90>], schedules=[])]

--- a/backend/app/schemas/plugins.py
+++ b/backend/app/schemas/plugins.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import List, Literal
+from typing import List, Literal, Union
+from fastapi import APIRouter
 
 class Route(BaseModel):
     handler: str
@@ -17,5 +18,8 @@ class Schedule(BaseModel):
 class PluginManifest(BaseModel):
     id: str = Field(pattern=r"^[a-z0-9-]+$")
     event_types: List[str] = []
-    routes: List[Route] = []
+    routes: List[Union[APIRouter, Route]] = []
     schedules: List[Schedule] = []
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/backend/plugins/core/manifest.py
+++ b/backend/plugins/core/manifest.py
@@ -1,11 +1,15 @@
-from app.schemas.plugins import PluginManifest, Route
+from app.schemas.plugins import PluginManifest
+from app.routers.skus import router as skus_router
+from app.routers.carbon import router as carbon_router
+from app.routers.events import router as events_router
+from app.routers.tokens import router as tokens_router
 
 manifest = PluginManifest(
     id="core",
     routes=[
-        Route(handler="app.routers.skus:router", prefix=""),
-        Route(handler="app.routers.carbon:router", prefix=""),
-        Route(handler="app.routers.events:router", prefix=""),
-        Route(handler="app.routers.tokens:router", prefix=""),
+        skus_router,
+        carbon_router,
+        events_router,
+        tokens_router,
     ],
 )


### PR DESCRIPTION
## Summary
- support `APIRouter` objects in plugin manifests
- mount core routers directly via plugin manifest
- rebuild `backend/app/registry.py`

## Testing
- `scripts/gen_registry.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684b39e7b4fc8322bf3f4343918ac76b