### PR TITLE
Use event_type table with index

### DIFF
--- a/backend/alembic/versions/9d42b6ef8b3e_event_type_lookup.py
+++ b/backend/alembic/versions/9d42b6ef8b3e_event_type_lookup.py
@@ -18,20 +18,23 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        'eventtype',
+        'event_type',
         sa.Column('id', sa.String(length=32), primary_key=True),
         sa.Column('json_schema', sa.JSON(), nullable=False, server_default='{}'),
     )
 
     with op.batch_alter_table('savingevent') as batch_op:
-        batch_op.add_column(sa.Column('event_type_id', sa.String(length=32), nullable=False, server_default='default'))
-        batch_op.create_foreign_key('fk_savingevent_event_type', 'eventtype', ['event_type_id'], ['id'])
+        batch_op.add_column(
+            sa.Column('event_type_id', sa.String(length=32), nullable=False, server_default='default')
+        )
+        batch_op.create_foreign_key('fk_savingevent_event_type', 'event_type', ['event_type_id'], ['id'])
+    op.create_index('ix_event_event_type', 'savingevent', ['event_type_id'])
 
 
 def downgrade() -> None:
     with op.batch_alter_table('savingevent') as batch_op:
         batch_op.drop_constraint('fk_savingevent_event_type', type_='foreignkey')
         batch_op.drop_column('event_type_id')
-
-    op.drop_table('eventtype')
+    op.drop_index('ix_event_event_type', table_name='savingevent')
+    op.drop_table('event_type')
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -62,6 +62,7 @@ class CarbonSnapshot(SQLModel, table=True):
 
 # ─────────────────── Plugin event types ────────────────────
 class EventType(SQLModel, table=True):
+    __tablename__ = "event_type"
     """Lookup table for saving event types with JSON schema."""
 
     id: str = Field(primary_key=True, max_length=32)
@@ -76,7 +77,12 @@ class SavingEvent(SQLModel, table=True):
     id: UUID | None = Field(default_factory=uuid4, primary_key=True)
     project_id: UUID = Field(index=True)
     feature: str
-    event_type_id: str = Field(foreign_key="eventtype.id", nullable=False, default="default")
+    event_type_id: str = Field(
+        foreign_key="event_type.id",
+        nullable=False,
+        default="default",
+        index=True,
+    )
     kwh: float
     co2: float
     usd: Decimal


### PR DESCRIPTION
## Summary
- fix event type table naming
- create index on `savingevent.event_type_id`
- update models to use the new table name

## Testing
- `pytest -q` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_684b39fd8358832295d349160df5bddb