### PR TITLE
Add smoke-build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CarbonCore
+
+This repository contains a FastAPI backend and a Next.js web console.
+
+## Smoke build
+
+Run the smoke build script to verify that both the backend and the web console build correctly:
+
+```bash
+scripts/smoke-build.sh
+```
+
+The script starts the backend with `uvicorn` and builds the web console using `pnpm`. It fails if either process exits with a non-zero status.

--- a/scripts/smoke-build.sh
+++ b/scripts/smoke-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start backend server in background
+uvicorn --app-dir backend app.main:app > /tmp/backend.log 2>&1 &
+BACKEND_PID=$!
+
+# Build web console in background
+(
+  cd web
+  pnpm build
+) > /tmp/web-build.log 2>&1 &
+WEB_PID=$!
+
+trap 'kill $BACKEND_PID $WEB_PID 2>/dev/null || true' EXIT
+
+# Wait for web build to finish
+WEB_STATUS=0
+BACKEND_STATUS=0
+wait $WEB_PID || WEB_STATUS=$?
+
+# Stop backend after web build completes
+kill $BACKEND_PID 2>/dev/null || true
+wait $BACKEND_PID || BACKEND_STATUS=$?
+
+# Consider termination signals as success
+if [ "$BACKEND_STATUS" -ne 0 ] && [ "$BACKEND_STATUS" -ne 130 ] && [ "$BACKEND_STATUS" -ne 143 ]; then
+  echo "backend exited with code $BACKEND_STATUS" >&2
+  exit 1
+fi
+
+if [ "$WEB_STATUS" -ne 0 ]; then
+  echo "web build failed with code $WEB_STATUS" >&2
+  exit 1
+fi
+
+echo "\u2705 smoke-build succeeded"


### PR DESCRIPTION
## Summary
- add script `smoke-build.sh` to concurrently start the backend and run the web build
- document smoke-build usage

## Testing
- `./scripts/smoke-build.sh` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_684b3a11ca3883228df5d1c0da57db16