### PR TITLE
Add index for SavingEvent.event_type_id

### DIFF
--- a/backend/alembic/versions/9d42b6ef8b3e_event_type_lookup.py
+++ b/backend/alembic/versions/9d42b6ef8b3e_event_type_lookup.py
@@ -24,12 +24,29 @@ def upgrade() -> None:
     )
 
     with op.batch_alter_table('savingevent') as batch_op:
-        batch_op.add_column(sa.Column('event_type_id', sa.String(length=32), nullable=False, server_default='default'))
-        batch_op.create_foreign_key('fk_savingevent_event_type', 'eventtype', ['event_type_id'], ['id'])
+        batch_op.add_column(
+            sa.Column(
+                'event_type_id',
+                sa.String(length=32),
+                nullable=False,
+                server_default='default',
+            )
+        )
+        batch_op.create_foreign_key(
+            'fk_savingevent_event_type',
+            'eventtype',
+            ['event_type_id'],
+            ['id'],
+        )
+        batch_op.create_index(
+            'ix_savingevent_event_type_id',
+            ['event_type_id'],
+        )
 
 
 def downgrade() -> None:
     with op.batch_alter_table('savingevent') as batch_op:
+        batch_op.drop_index('ix_savingevent_event_type_id')
         batch_op.drop_constraint('fk_savingevent_event_type', type_='foreignkey')
         batch_op.drop_column('event_type_id')
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -76,7 +76,12 @@ class SavingEvent(SQLModel, table=True):
     id: UUID | None = Field(default_factory=uuid4, primary_key=True)
     project_id: UUID = Field(index=True)
     feature: str
-    event_type_id: str = Field(foreign_key="eventtype.id", nullable=False, default="default")
+    event_type_id: str = Field(
+        foreign_key="eventtype.id",
+        nullable=False,
+        default="default",
+        index=True,
+    )
     kwh: float
     co2: float
     usd: Decimal


### PR DESCRIPTION
## Summary
- index `event_type_id` in `SavingEvent`
- ensure Alembic migration creates/drops this index

## Testing
- `poetry run ruff .` *(fails: Failed to parse celeryconfig.py)*
- `poetry run mypy .` *(fails: unterminated triple-quoted string literal)*
- `poetry run pytest -q` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_684b3a2cf4e8832283b15b37ebf78be5