### PR TITLE
Add Kubernetes quickstart script

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,16 @@
+# Infrastructure
+
+This directory contains Helm charts and helper scripts.
+
+## Quickstart
+
+Use `quickstart.sh` to spin up dependencies in a Kubernetes cluster.
+It creates the `carboncore-stg` namespace and deploys PostgreSQL and
+Redis using the Bitnami Helm charts.
+
+```bash
+./quickstart.sh
+```
+
+Ensure `helm` and `kubectl` point to your cluster before running the script.
+

--- a/infra/quickstart.sh
+++ b/infra/quickstart.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="carboncore-stg"
+
+# Create namespace if it doesn't exist
+kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 || \
+  kubectl create namespace "$NAMESPACE"
+
+# Add Bitnami repo for PostgreSQL and Redis charts
+helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
+helm repo update
+
+# Deploy PostgreSQL
+helm upgrade --install carboncore-postgresql bitnami/postgresql \
+  --namespace "$NAMESPACE" \
+  --set auth.postgresPassword=postgres \
+  --set auth.database=carboncore
+
+# Deploy Redis
+helm upgrade --install carboncore-redis bitnami/redis \
+  --namespace "$NAMESPACE" \
+  --set auth.enabled=false
+


### PR DESCRIPTION
## Summary
- add `infra/quickstart.sh` to create `carboncore-stg` namespace and install Postgres + Redis via Helm
- document the quickstart process in `infra/README.md`

## Testing
- `poetry run ruff check app` *(fails: Invalid rule code WPS433)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684b3a1e9e488322abc323ad3accbb81