### PR TITLE
Fix registry generator and plugin task test

### DIFF
--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -1,8 +1,11 @@
-from app.schemas.plugins import PluginManifest, Route
+from typing import Dict
 
-REGISTRY: dict[str, PluginManifest] = {
-    "core": PluginManifest(**{'id': 'core', 'event_types': [], 'routes': [{'handler': 'app.routers.skus:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'app.routers.carbon:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'app.routers.events:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'app.routers.tokens:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'schedules': []}),
+from app.schemas.plugins import PluginManifest
+from plugins.core.manifest import manifest as core_manifest
+
+REGISTRY: Dict[str, PluginManifest] = {
+    "core": core_manifest,
 }
 
-registry = REGISTRY  # FastAPI alias
+registry = REGISTRY
 __all__ = ['REGISTRY', 'registry']

--- a/backend/app/tasks/loader.py
+++ b/backend/app/tasks/loader.py
@@ -1,11 +1,21 @@
+"""Utility for registering plugin tasks with Celery."""
+
 from importlib import import_module
+from celery import Celery
 from app.registry import REGISTRY
 
 
-def load_plugin_tasks(celery_app) -> None:
-    """Register tasks from plugin manifests."""
+def load_plugin_tasks(celery_app: Celery) -> None:
+    """Register tasks from plugin manifests.
+
+    The new manifest schema exposes ``schedules`` rather than a bare ``tasks``
+    list.  Each schedule defines the dotted path to the task callable.  For now
+    we simply register each referenced task with Celery so it becomes available
+    for ``celery inspect registered``.
+    """
+
     for manifest in REGISTRY.values():
-        for path in manifest.tasks:
-            module, func = path.rsplit(".", 1)
-            fn = getattr(import_module(module), func)
-            celery_app.task(fn)
+        for sch in getattr(manifest, "schedules", []):
+            module, func = sch.task.split(":")
+            target = getattr(import_module(module), func)
+            celery_app.task(target, name=sch.name)

--- a/backend/tests/test_plugin_tasks.py
+++ b/backend/tests/test_plugin_tasks.py
@@ -1,5 +1,5 @@
 from celery import Celery
-from app.plugin_manifest import PluginManifest
+from app.schemas.plugins import PluginManifest, Schedule
 from app.tasks.loader import load_plugin_tasks
 from app.registry import REGISTRY
 
@@ -8,13 +8,18 @@ from tests.dummy_plugin import dummy_task
 
 
 def test_load_plugin_tasks_registers():
-    celery_app = Celery('test', broker='memory://', backend='cache+memory://')
-    plugin = PluginManifest(id='dummy', tasks=['tests.dummy_plugin.dummy_task'])
+    celery_app = Celery("test", broker="memory://", backend="cache+memory://")
+    plugin = PluginManifest(
+        id="dummy",
+        schedules=[
+            Schedule(name="dummy", task="tests.dummy_plugin:dummy_task")
+        ],
+    )
     original = REGISTRY.copy()
     try:
         REGISTRY['dummy'] = plugin
         load_plugin_tasks(celery_app)
-        assert 'tests.dummy_plugin.dummy_task' in celery_app.tasks
+        assert "dummy" in celery_app.tasks
     finally:
         REGISTRY.clear()
         REGISTRY.update(original)


### PR DESCRIPTION
## Summary
- update Celery plugin loader to read new manifest schedules
- refresh test fixture for plugin tasks
- rework registry generator to import manifests directly
- rebuild `backend/app/registry.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b535f1ca083228be6343a201859ab