### PR TITLE
Add infra docs and fix plugin imports

### DIFF
--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -1,13 +1,13 @@
 from typing import Dict
 
 from app.schemas.plugins import PluginManifest
-from plugins.carbon-comply.manifest import manifest as carbon_comply_manifest
-from plugins.eco-shift.manifest import manifest as eco_shift_manifest
+from plugins.ecoshift.manifest import manifest as eco_shift_manifest
+from plugins.carboncomply.manifest import manifest as carbon_comply_manifest
 from plugins.core.manifest import manifest as core_manifest
 
 REGISTRY: Dict[str, PluginManifest] = {
-    "carbon-comply": carbon_comply_manifest,
     "eco-shift": eco_shift_manifest,
+    "carbon-comply": carbon_comply_manifest,
     "core": core_manifest,
 }
 

--- a/backend/plugins/carboncomply/carboncomply/alert.py
+++ b/backend/plugins/carboncomply/carboncomply/alert.py
@@ -1,4 +1,8 @@
-from backend.worker.loader import app
+from celery import Celery
+try:
+    from backend.worker.loader import app
+except Exception:
+    app = Celery("carboncore")
 import os, requests
 
 @app.task(name="offset.alert")

--- a/backend/plugins/carboncomply/carboncomply/views.py
+++ b/backend/plugins/carboncomply/carboncomply/views.py
@@ -1,11 +1,14 @@
 from fastapi import Depends
 from fastapi.responses import StreamingResponse
 from sqlalchemy import text
-from app.database import SessionLocal
+from app.core.deps import SessionLocal
 import pandas as pd, io
 
 def export_xlsx(year: int, db=Depends(SessionLocal)):
-    q = db.execute(text("SELECT * FROM vw_esrs WHERE date_part('year',q)=:y"), dict(y=year))
+    q = db.execute(
+        text("SELECT * FROM vw_esrs WHERE date_part('year', ts)=:y"),
+        dict(y=year),
+    )
     df = pd.DataFrame(q.fetchall(), columns=q.keys())
     buf = io.BytesIO()
     df.to_excel(buf, index=False)

--- a/backend/plugins/ecoshift/ecoshift/autopilot.py
+++ b/backend/plugins/ecoshift/ecoshift/autopilot.py
@@ -1,5 +1,9 @@
 from datetime import datetime, timedelta
-from backend.worker.loader import app
+from celery import Celery
+try:
+    from backend.worker.loader import app
+except Exception:  # fall back when backend package not on path
+    app = Celery("carboncore")
 from plugins.ecoshift.ecoshift.views import suggest
 
 @app.task(name="shift.autopilot")

--- a/backend/plugins/ecoshift/ecoshift/views.py
+++ b/backend/plugins/ecoshift/ecoshift/views.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Body
 from datetime import datetime, timedelta
 from sqlalchemy import text
-from app.database import SessionLocal
+from app.core.deps import SessionLocal
 
 router = APIRouter()
 
@@ -20,7 +20,7 @@ def forecast_carbon(zone: str, hours: int = 24, db=Depends(SessionLocal)):
     return [dict(r) for r in q]
 
 @router.post("/suggest")
-def suggest(job: dict, db=Depends(SessionLocal)):
+def suggest(job: dict = Body(...), db=Depends(SessionLocal)):
     earliest = datetime.fromisoformat(job["earliest"])
     latest = datetime.fromisoformat(job["latest"])
     q = db.execute(

--- a/infra/README.md
+++ b/infra/README.md
@@ -14,3 +14,23 @@ Redis using the Bitnami Helm charts.
 
 Ensure `helm` and `kubectl` point to your cluster before running the script.
 
+
+## LaunchDarkly flags
+
+The `launchdarkly/` folder contains an export of feature flags used by the
+application. Run `bootstrap_flags.sh` to import them into your project:
+
+```bash
+cd infra/launchdarkly && ./bootstrap_flags.sh
+```
+
+## S3 exports bucket
+
+CarbonComply writes XLSX exports to an S3 bucket. Provision it once with the
+helper script below (requires the AWS CLI):
+
+```bash
+cd infra/s3 && ./create_exports_bucket.sh
+```
+
+The bucket is named `carboncore-exports` and expires objects after 30 days.

--- a/infra/launchdarkly/bootstrap_flags.sh
+++ b/infra/launchdarkly/bootstrap_flags.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Bootstrap LaunchDarkly flags for CarbonCore plug-ins
+set -euo pipefail
+
+if ! command -v ldctl >/dev/null; then
+  echo "ldctl not installed" >&2
+  exit 1
+fi
+
+PROJECT=${LD_PROJECT:-carboncore}
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+ldctl import --project "$PROJECT" "$SCRIPT_DIR/flags.json"

--- a/infra/launchdarkly/flags.json
+++ b/infra/launchdarkly/flags.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "key": "shift.enabled",
+      "name": "EcoShift enabled",
+      "environments": {"production": {"on": true}}
+    },
+    {
+      "key": "comply.enabled",
+      "name": "CarbonComply enabled",
+      "environments": {"production": {"on": true}}
+    }
+  ]
+}

--- a/infra/s3/create_exports_bucket.sh
+++ b/infra/s3/create_exports_bucket.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Create the S3 bucket used for CarbonComply exports
+set -euo pipefail
+
+BUCKET="carboncore-exports"
+REGION=${AWS_REGION:-us-east-1}
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+
+aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" --create-bucket-configuration LocationConstraint="$REGION"
+aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" --lifecycle-configuration file://$SCRIPT_DIR/lifecycle.json

--- a/infra/s3/lifecycle.json
+++ b/infra/s3/lifecycle.json
@@ -1,0 +1,10 @@
+{
+  "Rules": [
+    {
+      "ID": "expire-exports",
+      "Status": "Enabled",
+      "Prefix": "",
+      "Expiration": { "Days": 30 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- seed LaunchDarkly feature flags and add bootstrap script
- document S3 exports bucket and provide helper script
- fix SQL alias in CarbonComply export
- update plugin tasks to load when backend package missing
- generate registry using plugin packages

## Testing
- `pytest -q` *(fails: test_suggest 422)*

------
https://chatgpt.com/codex/tasks/task_e_684b6c5b67208322b3b20b4425d8c7e5