### PR TITLE
Implement missing dashboard tiles

### DIFF
--- a/web/app/dashboard/page.js
+++ b/web/app/dashboard/page.js
@@ -3,27 +3,52 @@ import useSWR from 'swr';
 import { Card, CardContent } from '@/components/ui/card';
 import { Bar } from 'react-chartjs-2';
 
+const fetcher = (url) =>
+  fetch(url, { headers: { 'x-project-token': 'demo' } }).then((r) => r.json());
+
 export default function SavingsChart() {
-  const { data } = useSWR('/events/?limit=100', (url) =>
-    fetch(url, { headers: { 'x-project-token': 'demo' } }).then((r) => r.json())
+  const { data } = useSWR('/events/?limit=100', fetcher);
+  const { data: shifted } = useSWR(
+    '/events?kind=ecs_shift&aggregate=count',
+    fetcher
+  );
+  const { data: co2 } = useSWR(
+    '/events?field=meta.kg_co2&aggregate=sum',
+    fetcher
   );
   if (!data) return 'Loading…';
 
   return (
-    <Card className="m-6">
-      <CardContent>
-        <Bar
-          data={{
-            labels: data.items.map((e) =>
-              new Date(e.timestamp).toLocaleDateString()
-            ),
-            datasets: [
-              { label: 'kg CO₂ saved', data: data.items.map((e) => e.kg_co2_saved) },
-            ],
-          }}
-          options={{ responsive: true }}
-        />
-      </CardContent>
-    </Card>
+    <div className="m-6 space-y-6">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="p-4 border rounded">
+          Jobs shifted — <span id="shifted">{shifted ? shifted.count : '…'}</span>
+        </div>
+        <div className="p-4 border rounded">
+          kg CO₂ avoided —{' '}
+          <span id="co2">
+            {co2 ? ((co2.sum || 0).toFixed(1)) : '…'}
+          </span>
+        </div>
+      </div>
+      <Card>
+        <CardContent>
+          <Bar
+            data={{
+              labels: data.items.map((e) =>
+                new Date(e.timestamp).toLocaleDateString()
+              ),
+              datasets: [
+                {
+                  label: 'kg CO₂ saved',
+                  data: data.items.map((e) => e.kg_co2_saved),
+                },
+              ],
+            }}
+            options={{ responsive: true }}
+          />
+        </CardContent>
+      </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- display Jobs shifted and kg CO₂ avoided on the dashboard
- make EcoShift DB calls async-friendly and handle missing data gracefully
- tag repository as `plugins-sprint1`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b733f7cbc8322996b87fdf522cede