### PR TITLE
Add latency tile and overshoot alert

### DIFF
--- a/backend/plugins/budget/budget/alert.py
+++ b/backend/plugins/budget/budget/alert.py
@@ -1,0 +1,15 @@
+import os, requests
+from backend.worker.loader import app
+from app.models import Event, SessionLocal
+
+SLACK = os.getenv("SLACK_WEBHOOK")
+
+@app.task(name="budget.overshoot")
+def overshoot():
+    with SessionLocal() as db:
+        rows = db.execute(
+            "SELECT * FROM carbon_budget WHERE (cap_tco2 - used_tco2) < 1"
+        )
+        for row in rows:
+            requests.post(SLACK, json={"text": f"\u26a0 Budget for project {row.id} nearly exhausted"})
+            Event.create(event_type_id="budget_overshoot", meta={"budget_id": row.id})

--- a/backend/plugins/budget/manifest.py
+++ b/backend/plugins/budget/manifest.py
@@ -1,10 +1,10 @@
 from app.schemas.plugins import PluginManifest, Route, Schedule
 manifest = PluginManifest(
  id="budget-copilot",
- event_types=["budget_forecast"],
+ event_types=["budget_forecast", "budget_overshoot"],
  routes=[Route(handler="plugins.budget.budget.views:router", prefix="")],
  schedules=[
   Schedule(name="budget.forecast", task="plugins.budget.budget.forecast:hourly", every=3600),
-  {"name":"budget.overshoot","task":"plugins.budget.budget.forecast:hourly","every":3600}
+  Schedule(name="budget.overshoot", task="plugins.budget.budget.alert:overshoot", every=3600)
  ]
 )

--- a/web/app/dashboard/page.js
+++ b/web/app/dashboard/page.js
@@ -1,5 +1,6 @@
 'use client';
 import useSWR from 'swr';
+import { useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Bar } from 'react-chartjs-2';
 
@@ -16,6 +17,15 @@ export default function SavingsChart() {
     '/events?field=meta.kg_co2&aggregate=sum',
     fetcher
   );
+
+  useEffect(() => {
+    fetch('/events?kind=edge_route&aggregate=avg&field=meta.rtt')
+      .then((r) => r.json())
+      .then(({ avg }) => {
+        const el = document.getElementById('lat');
+        if (el) el.textContent = String(Math.round(avg ?? 0));
+      });
+  }, []);
   if (!data) return 'Loading…';
 
   return (
@@ -29,6 +39,9 @@ export default function SavingsChart() {
           <span id="co2">
             {co2 ? ((co2.sum || 0).toFixed(1)) : '…'}
           </span>
+        </div>
+        <div className="p-4 border rounded">
+          Avg latency Δ — <span id="lat">0</span> ms
         </div>
       </div>
       <Card>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,11 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { sidebar } from "../sidebar-meta";
 export default function Layout({ children }:{children:ReactNode}){
+  useEffect(()=>{
+    fetch("/events?kind=budget_overshoot")
+      .then(r=>r.json())
+      .then(({items})=>{ if(items?.length) localStorage.setItem("overshoot","1");});
+  },[]);
   return (
     <div className="flex">
       <aside className="w-56 border-r p-4 space-y-2">


### PR DESCRIPTION
## Summary
- display avg latency on dashboard
- add overshoot Slack task and schedule
- store overshoot flag in localStorage when alert events are fetched

## Testing
- `scripts/smoke-build.sh` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*
- `ldctl flags create edge-router.enabled --on true --default-off` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb28e9efc832295af101b5462a7a7