### PR TITLE
Add EcoLabel hook endpoint and test fixture

### DIFF
--- a/backend/plugins/ecolabel/ecolabel/hooks.py
+++ b/backend/plugins/ecolabel/ecolabel/hooks.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.core.deps import get_db
+
+router = APIRouter()
+
+@router.post("/hooks/ecolabel")
+async def record_ecolabel(evt: dict, db: AsyncSession = Depends(get_db)):
+    await db.execute(
+        text("INSERT INTO event (event_type_id, meta) VALUES (:t, :m)"),
+        {"t": "ecolabel_view", "m": evt},
+    )
+    await db.commit()
+    return {"status": "ok"}

--- a/backend/plugins/ecolabel/manifest.py
+++ b/backend/plugins/ecolabel/manifest.py
@@ -1,6 +1,9 @@
 from app.schemas.plugins import PluginManifest, Route
 manifest = PluginManifest(
- id="eco-label",
- event_types=["ecolabel_view"],
- routes=[Route(handler="plugins.ecolabel.ecolabel.views:router", prefix="")]
+    id="eco-label",
+    event_types=["ecolabel_view"],
+    routes=[
+        Route(handler="plugins.ecolabel.ecolabel.views:router", prefix=""),
+        Route(handler="plugins.ecolabel.ecolabel.hooks:router", prefix=""),
+    ],
 )

--- a/web/e2e/ecolabel.spec.ts
+++ b/web/e2e/ecolabel.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-test("Widget badge appears", async ({ page })=>{
-  await page.goto("/widget/widget.js"); // loads badge via script tag
+test("Widget badge appears", async ({ page }) => {
+  await page.goto("/test_widget.html");
   await expect(page.locator("text=/CO₂/")).toBeVisible();
 });

--- a/web/public/test_widget.html
+++ b/web/public/test_widget.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+<script src="/widget/widget.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `/hooks/ecolabel` POST endpoint
- mount the hook router in the EcoLabel manifest
- add simple public fixture page for the widget
- fix Playwright test to open the new page

## Testing
- `pytest -q` *(fails: OSError connecting to PostgreSQL and module errors)*
- `npx playwright test` *(failed to install playwright)*
- `npx lhci autorun` *(failed: needed package install)*

------
https://chatgpt.com/codex/tasks/task_e_684cbdb999208322a04c2f56f11030e5