### PR TITLE
Add alerting for pulse and offset-sync manifest

### DIFF
--- a/backend/alembic/versions/20240701_event_log.py
+++ b/backend/alembic/versions/20240701_event_log.py
@@ -1,0 +1,19 @@
+"""event log table"""
+from alembic import op
+import sqlalchemy as sa
+revision = '20240701_event_log'
+down_revision = '20240613_ledger_rls'
+
+def upgrade() -> None:
+    op.create_table(
+        'event',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('event_type_id', sa.String(length=32), nullable=False),
+        sa.Column('meta', sa.JSON(), nullable=False, server_default='{}'),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index('ix_event_type', 'event', ['event_type_id'])
+
+def downgrade() -> None:
+    op.drop_index('ix_event_type', table_name='event')
+    op.drop_table('event')

--- a/backend/alembic/versions/20240702_supplier_table.py
+++ b/backend/alembic/versions/20240702_supplier_table.py
@@ -1,0 +1,17 @@
+"""supplier table"""
+from alembic import op
+import sqlalchemy as sa
+revision = '20240702_supplier_table'
+down_revision = '20240701_event_log'
+
+def upgrade() -> None:
+    op.create_table(
+        'supplier',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('url', sa.String(), nullable=False),
+        sa.Column('sla_gco2', sa.Float(), nullable=False),
+    )
+
+def downgrade() -> None:
+    op.drop_table('supplier')

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -9,6 +9,7 @@ from plugins.budget.manifest import manifest as budget_copilot_manifest
 from plugins.carboncomply.manifest import manifest as carbon_comply_manifest
 from plugins.greendev.manifest import manifest as green_dev_manifest
 from plugins.edge_router.manifest import manifest as edge_router_manifest
+from plugins.offset_sync.manifest import manifest as offset_sync_manifest
 
 REGISTRY: Dict[str, PluginManifest] = {
     "eco-shift": eco_shift_manifest,
@@ -19,6 +20,7 @@ REGISTRY: Dict[str, PluginManifest] = {
     "carbon-comply": carbon_comply_manifest,
     "green-dev": green_dev_manifest,
     "edge-router": edge_router_manifest,
+    "offset-sync": offset_sync_manifest,
 }
 
 registry = REGISTRY

--- a/backend/plugins/offset_sync/manifest.py
+++ b/backend/plugins/offset_sync/manifest.py
@@ -1,0 +1,6 @@
+from app.schemas.plugins import PluginManifest
+
+manifest = PluginManifest(
+    id="offset-sync",
+    event_types=["offset_buy", "saving"],
+)

--- a/backend/plugins/offset_sync/pyproject.toml
+++ b/backend/plugins/offset_sync/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "offset_sync"
+version = "0.1.0"
+description = "Offset Sync plugin"
+requires-python = ">=3.9"
+dependencies = ["fastapi", "sqlmodel"]

--- a/backend/plugins/pulse/pulse/alert.py
+++ b/backend/plugins/pulse/pulse/alert.py
@@ -1,0 +1,36 @@
+import os
+import requests
+from sqlalchemy import text
+from backend.worker.loader import app
+from app.database import SessionLocal
+
+SLACK = os.getenv("SLACK_WEBHOOK")
+
+@app.task(name="pulse.alert")
+def alert_suppliers():
+    """Notify when a supplier scan exceeds its SLA."""
+    if not SLACK:
+        return
+    with SessionLocal() as db:
+        rows = db.execute(
+            text(
+                "SELECT id, meta FROM event WHERE event_type_id='supplier_scan' "
+                "AND (meta->>'alert') IS NULL AND "
+                "(meta->>'g_co2')::float > (meta->>'sla')::float"
+            )
+        )
+        for evt_id, meta in rows:
+            requests.post(
+                SLACK,
+                json={
+                    "text": f"\u26a0 {meta['supplier']} {meta['g_co2']:.2f} gCO2 exceeds {meta['sla']:.2f}"
+                },
+            )
+            db.execute(
+                text(
+                    "UPDATE event SET meta = jsonb_set(meta,'{alert}','\"1\"',true) "
+                    "WHERE id = :id"
+                ),
+                dict(id=evt_id),
+            )
+        db.commit()

--- a/backend/plugins/pulse/pulse/scanner.py
+++ b/backend/plugins/pulse/pulse/scanner.py
@@ -7,6 +7,13 @@ import random, datetime
 def nightly():
     with SessionLocal() as db:
         for sup in db.query(Supplier):
-            g=random.uniform(sup.sla_gco2*0.8, sup.sla_gco2*1.2)
-            Event.create(event_type_id="supplier_scan",
-                         meta={"supplier":sup.name,"g_co2":g,"ts":datetime.datetime.utcnow().isoformat()})
+            g = random.uniform(sup.sla_gco2 * 0.8, sup.sla_gco2 * 1.2)
+            Event.create(
+                event_type_id="supplier_scan",
+                meta={
+                    "supplier": sup.name,
+                    "g_co2": g,
+                    "sla": sup.sla_gco2,
+                    "ts": datetime.datetime.utcnow().isoformat(),
+                },
+            )


### PR DESCRIPTION
## Summary
- log supplier SLA in pulse scanner
- add alerting task for pulse plugin with dedupe
- register new offset-sync plugin and manifest
- create event and supplier tables via Alembic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684d5311c6d48322b2ad499dc29fd770