### PR TITLE
Add dev secrets fallback

### DIFF
--- a/backend/app/secret.py
+++ b/backend/app/secret.py
@@ -1,8 +1,38 @@
-import os, json, boto3, functools
+import os, json, functools
+from typing import Dict
+
+try:
+    import boto3, botocore.exceptions  # prod / staging only
+except ModuleNotFoundError:  # unit-tests
+    boto3 = None
 @functools.lru_cache
-def get_secret():
-    sm = boto3.client(
-        "secretsmanager",
-        region_name=os.getenv("AWS_REGION", "us-east-1"),
-    )
-    return json.loads(sm.get_secret_value(SecretId="carboncore/staging")["SecretString"])
+def get_secret() -> Dict[str, str]:
+    """
+    Dev → read from env if AWS creds absent.
+    Prod → pull JSON blob from AWS Secrets Manager.
+    """
+    # 1️⃣ fast path: env var override
+    if os.getenv("SKIP_AWS_SECRETS", "false").lower() == "true" or boto3 is None:
+        return {
+            "POSTGRES_PASSWORD": os.getenv("POSTGRES_PASSWORD", "postgres"),
+            "REDIS_URL": os.getenv("REDIS_URL", "redis://redis:6379/0"),
+            "SLACK_WEBHOOK": os.getenv("SLACK_WEBHOOK", ""),
+        }
+    # 2️⃣ try AWS, fall back if credentials missing
+    try:
+        sm = boto3.client(
+            "secretsmanager",
+            region_name=os.getenv("AWS_REGION", "us-east-1"),
+        )
+        return json.loads(
+            sm.get_secret_value(
+                SecretId=os.getenv("AWS_SECRET_NAME", "carboncore/staging")
+            )["SecretString"]
+        )
+    except botocore.exceptions.NoCredentialsError:
+        print("\u26a0  AWS creds not found, falling back to env vars")
+        return {
+            "POSTGRES_PASSWORD": os.getenv("POSTGRES_PASSWORD", "postgres"),
+            "REDIS_URL": os.getenv("REDIS_URL", "redis://redis:6379/0"),
+            "SLACK_WEBHOOK": os.getenv("SLACK_WEBHOOK", ""),
+        }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,11 @@ services:
     volumes:
       - ./backend:/code              # live-reload during dev
     env_file: .env.development
-    environment: *common-env
+    environment:
+      <<: *common-env
+      SKIP_AWS_SECRETS: "true"
+      POSTGRES_PASSWORD: postgres
+      REDIS_URL: redis://redis:6379/0
     depends_on:
       db:
         condition: service_healthy
@@ -89,7 +93,11 @@ services:
       - ./backend:/code
       - celery_beat:/code/celerybeat-schedule.db
     env_file: .env.development
-    environment: *common-env
+    environment:
+      <<: *common-env
+      SKIP_AWS_SECRETS: "true"
+      POSTGRES_PASSWORD: postgres
+      REDIS_URL: redis://redis:6379/0
     depends_on:
       backend:
         condition: service_healthy
@@ -107,6 +115,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    profiles: ["prod"]
     restart: unless-stopped
 
   sku-crawler:
@@ -119,6 +128,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    profiles: ["prod"]
     restart: on-failure
 
   grafana-agent:


### PR DESCRIPTION
## Summary
- allow skipping AWS Secrets Manager in dev by falling back to env vars
- set `SKIP_AWS_SECRETS` and default passwords in docker compose
- run grid and SKU ingestors only in `prod` profile

## Testing
- `pip install -r requirements.txt`
- `pip install celery==5.5.3 sqlalchemy==2.0.41 sqlmodel==0.0.16 passlib==1.7.4 pydantic-settings==2.9.1 pydantic==2.11.5`
- `pytest ../tests` *(fails: ImportError due to incompatible fastapi/pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_684e16b7fb348322ba2715a4db29354a