### PR TITLE
Fix Next.js import aliases

### DIFF
--- a/web/app/(dashboard)/page.tsx
+++ b/web/app/(dashboard)/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import KpiTile from '@/src/components/KpiTile';
+import KpiTile from '@/components/KpiTile';
 import { useStats } from '@/hooks/useStats';
 import {
   LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,11 +1,11 @@
-import '@/src/styles/tokens.css';
-import '@/src/styles/globals.css';
+import '@/styles/tokens.css';
+import '@/styles/globals.css';
 import { ThemeProvider } from 'next-themes';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import BottomNav from '@/src/components/mobile/BottomNav';
-import { initAnalytics, analytics } from '@/src/lib/analytics';
+import BottomNav from '@/components/mobile/BottomNav';
+import { initAnalytics, analytics } from '@/lib/analytics';
 import { useEffect } from 'react';
-import ConsentBanner from '@/src/components/ConsentBanner';
+import ConsentBanner from '@/components/ConsentBanner';
 
 const client = new QueryClient();
 export const metadata = {


### PR DESCRIPTION
## Summary
- fix imports for dashboard components to match alias

## Testing
- `./scripts/smoke-build.sh` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684e3959a600832281a88611d6fdfc61