### PR TITLE
Add global UI fallbacks & plugin model

### DIFF
--- a/backend/alembic/versions/20240617_plugin_table.py
+++ b/backend/alembic/versions/20240617_plugin_table.py
@@ -1,0 +1,29 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlmodel.sql.sqltypes import AutoString
+
+# revision identifiers, used by Alembic.
+revision = "20240617_plugin_table"
+down_revision = "20240702_supplier_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plugins",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("name", AutoString(), nullable=False),
+        sa.Column("version", AutoString(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_plugins_id", "plugins", ["id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_plugins_id", table_name="plugins")
+    op.drop_table("plugins")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -112,8 +112,29 @@ class DSARLog(SQLModel, table=True):
     user_id: int
     ts: datetime = Field(default_factory=datetime.utcnow)
 
+
+# ─────────────────── Plugins registry ───────────────────────
+class Plugin(SQLModel, table=True):
+    __tablename__ = "plugins"
+
+    id: str = Field(primary_key=True, index=True)
+    name: str
+    version: str
+    created_at: datetime | None = Field(
+        default=None,
+        sa_column_kwargs={"server_default": "now()"},
+    )
+
 # ─────────────────── Model rebuilds ───────────────────────────
-for _model in (Sku, CarbonSnapshot, EventType, SavingEvent, ProjectToken, DSARLog):
+for _model in (
+    Sku,
+    CarbonSnapshot,
+    EventType,
+    SavingEvent,
+    ProjectToken,
+    DSARLog,
+    Plugin,
+):
     try:  # Pydantic v2
         _model.model_rebuild()
     except AttributeError:  # v1 fallback

--- a/web/src/app/(dashboard)/dashboard/loading.tsx
+++ b/web/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/ui/SkeletonDashboard'

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  /* optional: report to PostHog/Sentry */
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body className="grid h-screen place-content-center gap-6 text-center">
+        <h1 className="text-2xl font-semibold text-destructive">
+          Something went wrong 😓
+        </h1>
+        <button
+          onClick={() => reset()}
+          className="mx-auto rounded-lg border px-4 py-2 shadow-sm transition-all hover:bg-accent"
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/web/src/app/loading.tsx
+++ b/web/src/app/loading.tsx
@@ -1,0 +1,9 @@
+export default function GlobalLoading() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <span className="animate-pulse text-muted-foreground">
+        Loading CarbonCore console…
+      </span>
+    </div>
+  );
+}

--- a/web/src/ui/SkeletonDashboard.tsx
+++ b/web/src/ui/SkeletonDashboard.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function SkeletonDashboard() {
+  return (
+    <div className="p-6">
+      <div className="mb-6 flex flex-wrap gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-[150px] rounded-xl" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-72 w-full rounded-xl" />
+        <Skeleton className="h-72 w-full rounded-xl" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add app-level loading and error boundaries with sample dashboard skeleton
- export skeleton in dashboard loading route
- add Plugin SQLModel and alembic migration

## Testing
- `poetry run alembic upgrade head` *(fails: coroutine not awaited)*
- `pytest backend/tests/plugins` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6850758a2e2883229a55b5877f4f4c27