### PR TITLE
Add Sprint 2 UI skeleton

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 name: ci
 on: [push, pull_request]
 
-jobs:
-  test:
+  jobs:
+    test:
     runs-on: ubuntu-latest
 
     services:
@@ -77,3 +77,14 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: storybook-static
+
+  e2e:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with: { version: 9, run_install: true }
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm dev --port 3000 &
+      - run: pnpm exec playwright test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ cd web && pnpm i && pnpm dev
 # open http://localhost:3000
 ```
 
+### Auth setup
+
+Copy `.env.example` to `.env` and provide `GITHUB_ID`, `GITHUB_SECRET`,
+`NEXTAUTH_URL` and `NEXTAUTH_SECRET` values. Start the dev server and visit
+`/api/auth/signin` to sign in via GitHub.
+
 ### Install SDKs
 
 ```bash

--- a/carboncore-ui/app/(protected)/dashboard/page.tsx
+++ b/carboncore-ui/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,8 @@
+export default function Dashboard() {
+  return (
+    <section className="grid grid-cols-2 gap-6">
+      <div className="bg-white/5 rounded p-4">💰 $-saved (placeholder)</div>
+      <div className="bg-white/5 rounded p-4">🌱 CO₂-saved (placeholder)</div>
+    </section>
+  );
+}

--- a/carboncore-ui/app/(protected)/layout.tsx
+++ b/carboncore-ui/app/(protected)/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+import { AuthGuard } from "@/components/AuthGuard";
+import { AppShell } from "@/components/layout/AppShell";
+
+export default function ProtectedLayout({ children }: { children: ReactNode }) {
+  return (
+    <AuthGuard>
+      <AppShell>{children}</AppShell>
+    </AuthGuard>
+  );
+}

--- a/carboncore-ui/app/(protected)/ledger/page.tsx
+++ b/carboncore-ui/app/(protected)/ledger/page.tsx
@@ -1,0 +1,7 @@
+export default function Ledger() {
+  return (
+    <div className="text-center mt-20 text-xl opacity-50">
+      Ledger list coming soon…
+    </div>
+  );
+}

--- a/carboncore-ui/app/api/auth/[...nextauth]/route.ts
+++ b/carboncore-ui/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,31 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+import Email from "next-auth/providers/email";
+import { JWT } from "next-auth/jwt";
+
+const handler = NextAuth({
+  providers: [
+    GitHub({
+      clientId: process.env.GITHUB_ID!,
+      clientSecret: process.env.GITHUB_SECRET!
+    }),
+    Email({ server: process.env.EMAIL_SERVER!, from: "auth@carboncore.io" })
+  ],
+  callbacks: {
+    /**
+     * Attach CarbonCore role claim.
+     * TODO: Replace stub with real backend call.
+     */
+    async jwt({ token }: { token: JWT }) {
+      token.role = "developer"; // stub role
+      return token;
+    },
+    async session({ session, token }) {
+      // put role onto session object
+      (session as any).user.role = token.role;
+      return session;
+    }
+  }
+});
+
+export { handler as GET, handler as POST };

--- a/carboncore-ui/components/AuthGuard.tsx
+++ b/carboncore-ui/components/AuthGuard.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useSession } from "next-auth/react";
+import { usePathname, useRouter } from "next/navigation";
+import { ReactNode, useEffect } from "react";
+
+export function AuthGuard({ children }: { children: ReactNode }) {
+  const { status } = useSession();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.replace(`/api/auth/signin?callbackUrl=${pathname}`);
+    }
+  }, [status, pathname, router]);
+
+  if (status !== "authenticated") {
+    return null;
+  }
+  return <>{children}</>;
+}

--- a/carboncore-ui/components/layout/AppShell.tsx
+++ b/carboncore-ui/components/layout/AppShell.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { ModeToggle } from "@/components/ui/ModeToggle";
+
+const nav = [
+  { href: "/dashboard", label: "Dashboard", icon: "📊" },
+  { href: "/ledger", label: "Ledger", icon: "📜" }
+];
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen bg-cc-base text-white">
+      {/* Side-nav */}
+      <aside className="w-56 border-r border-white/10 hidden md:block">
+        <div className="h-16 flex items-center justify-center font-bold">
+          CarbonCore
+        </div>
+        <nav className="px-4 space-y-1">
+          {nav.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex items-center gap-3 px-2 py-2 rounded hover:bg-white/10"
+            >
+              <span>{item.icon}</span>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Main */}
+      <div className="flex-1 flex flex-col">
+        <header className="h-16 flex items-center justify-end px-6 gap-4 border-b border-white/10">
+          <ModeToggle />
+        </header>
+        <main className="p-6 flex-1">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/carboncore-ui/e2e/login.spec.ts
+++ b/carboncore-ui/e2e/login.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test("user can login and see dashboard", async ({ page }) => {
+  await page.goto("/api/auth/signin");
+  // Stub: Bypass real GitHub OAuth using test provider
+  await page.click("text=Sign in as test user");
+  await expect(page).toHaveURL("/dashboard");
+  await expect(page.getByText(/CO₂-saved/i)).toBeVisible();
+});

--- a/carboncore-ui/env.d.ts
+++ b/carboncore-ui/env.d.ts
@@ -1,0 +1,12 @@
+import { Session } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      role?: string;
+    };
+  }
+}

--- a/carboncore-ui/lib/auth.ts
+++ b/carboncore-ui/lib/auth.ts
@@ -1,0 +1,9 @@
+import { getServerSession } from "next-auth";
+import type { Role } from "@/types/roles";
+
+export async function getServerSessionWithRole() {
+  const session = (await getServerSession()) as (Awaited<ReturnType<typeof getServerSession>> & {
+    user?: { role?: Role };
+  });
+  return session;
+}

--- a/env.example
+++ b/env.example
@@ -10,3 +10,11 @@ AWS_SECRET_ACCESS_KEY=local
 
 # Front-end
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# NextAuth
+NEXTAUTH_SECRET=changeme-in-prod
+NEXTAUTH_URL=http://localhost:3000
+
+# GitHub OAuth
+GITHUB_ID=gh-oauth-client-id
+GITHUB_SECRET=gh-oauth-client-secret


### PR DESCRIPTION
## Summary
- append NextAuth variables to `.env.example`
- document auth setup instructions
- provide basic NextAuth handler with role claim
- add AuthGuard and AppShell layout with protected routes
- include stubbed dashboard and ledger pages
- integrate basic Playwright job in CI

## Testing
- `pnpm exec vitest run`
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6850868656b48322a7f1fcfcad7ef6ef