### PR TITLE
Implement Sprint 3 ledger timeline

### DIFF
--- a/carboncore-ui/app/(protected)/dashboard/page.tsx
+++ b/carboncore-ui/app/(protected)/dashboard/page.tsx
@@ -1,8 +1,16 @@
-export default function Dashboard() {
+import { fetchKpis } from "@/lib/kpi-api";
+
+export const dynamic = "force-dynamic";
+
+export default async function Dashboard() {
+  const kpis = await fetchKpis();
   return (
     <section className="grid grid-cols-2 gap-6">
-      <div className="bg-white/5 rounded p-4">💰 $-saved (placeholder)</div>
-      <div className="bg-white/5 rounded p-4">🌱 CO₂-saved (placeholder)</div>
+      {kpis.map((k) => (
+        <div key={k.label} className="bg-white/5 rounded p-4">
+          {k.label}: {k.value}
+        </div>
+      ))}
     </section>
   );
 }

--- a/carboncore-ui/app/(protected)/ledger/page.tsx
+++ b/carboncore-ui/app/(protected)/ledger/page.tsx
@@ -1,7 +1,55 @@
-export default function Ledger() {
+import { fetchLedger } from "@/lib/ledger-api";
+import { Suspense } from "react";
+import { EventRow } from "@/components/ledger/EventRow";
+import { useEventSource } from "@/lib/useEventSource";
+import { LedgerEvent } from "@/types/ledger";
+import { Virtualizer } from "@tanstack/react-virtual";
+
+export const dynamic = "force-dynamic";
+
+export default async function LedgerPage() {
+  const initial = await fetchLedger(50);
+
   return (
-    <div className="text-center mt-20 text-xl opacity-50">
-      Ledger list coming soon…
+    <section>
+      <h1 className="text-2xl font-semibold mb-4">Ledger</h1>
+      <Suspense fallback={<p>Loading events…</p>}>
+        <LiveList initial={initial} />
+      </Suspense>
+    </section>
+  );
+}
+
+/** Client component */
+function LiveList({ initial }: { initial: LedgerEvent[] }) {
+  "use client";
+  const newEvents = useEventSource<LedgerEvent>("/api/ledger/stream");
+  const events = [...newEvents, ...initial];
+
+  // virtualisation
+  const parentRef = React.useRef<HTMLDivElement>(null);
+  const rowVirtualizer = Virtualizer({
+    count: events.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 48
+  });
+
+  return (
+    <div ref={parentRef} className="h-[70vh] overflow-auto">
+      <div style={{ height: rowVirtualizer.getTotalSize() }} className="relative">
+        {rowVirtualizer.getVirtualItems().map((v) => {
+          const e = events[v.index];
+          return (
+            <div
+              key={e.id}
+              className="absolute top-0 left-0 right-0"
+              style={{ transform: `translateY(${v.start}px)` }}
+            >
+              <EventRow e={e} />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/carboncore-ui/app/api/kpi/route.ts
+++ b/carboncore-ui/app/api/kpi/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/kpi`;
+  const resp = await fetch(backendURL, { headers: { Authorization: req.headers.get("Authorization")! } });
+  const data = await resp.json();
+  return NextResponse.json(data);
+}

--- a/carboncore-ui/app/api/ledger/route.ts
+++ b/carboncore-ui/app/api/ledger/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const limit = req.nextUrl.searchParams.get("limit") ?? "50";
+  const backendURL = `${process.env.BACKEND_URL}/ledger?limit=${limit}`;
+  const resp = await fetch(backendURL, { headers: { Authorization: req.headers.get("Authorization")! } });
+  const data = await resp.json();
+  return NextResponse.json(data);
+}

--- a/carboncore-ui/app/api/ledger/stream/route.ts
+++ b/carboncore-ui/app/api/ledger/stream/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic"; // disable ISR for stream
+
+export async function GET(req: NextRequest) {
+  const { readable, writable } = new TransformStream();
+  const backend = await fetch(`${process.env.BACKEND_URL}/ledger/stream`, {
+    headers: { Accept: "text/event-stream" }
+  });
+  if (!backend.body) throw new Error("No stream");
+
+  backend.body.pipeTo(writable); // proxy bytes
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache"
+    }
+  });
+}

--- a/carboncore-ui/components/layout/AppShell.tsx
+++ b/carboncore-ui/components/layout/AppShell.tsx
@@ -1,13 +1,14 @@
 import Link from "next/link";
 import { ReactNode } from "react";
 import { ModeToggle } from "@/components/ui/ModeToggle";
+import { NAV_BY_ROLE } from "@/lib/nav";
+import { getServerSessionWithRole } from "@/lib/auth";
 
-const nav = [
-  { href: "/dashboard", label: "Dashboard", icon: "📊" },
-  { href: "/ledger", label: "Ledger", icon: "📜" }
-];
+export async function AppShell({ children }: { children: ReactNode }) {
+  const session = await getServerSessionWithRole();
+  const role = (session?.user?.role as keyof typeof NAV_BY_ROLE) || "developer";
+  const nav = NAV_BY_ROLE[role];
 
-export function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen bg-cc-base text-white">
       {/* Side-nav */}

--- a/carboncore-ui/components/ledger/EventRow.tsx
+++ b/carboncore-ui/components/ledger/EventRow.tsx
@@ -1,0 +1,14 @@
+import { LedgerEvent } from "@/types/ledger";
+import { format } from "date-fns";
+
+export function EventRow({ e }: { e: LedgerEvent }) {
+  return (
+    <div className="grid grid-cols-[120px_1fr_80px_80px_80px] gap-4 py-2 border-b border-white/10" data-row>
+      <div className="font-mono text-xs text-white/70">{format(new Date(e.ts), "yyyy-MM-dd HH:mm")}</div>
+      <div>{e.service}@{e.region}</div>
+      <div className="text-right">{e.kwh.toFixed(2)} kWh</div>
+      <div className="text-right">{e.co2.toFixed(2)} kg</div>
+      <div className="text-right">${e.usd.toFixed(2)}</div>
+    </div>
+  );
+}

--- a/carboncore-ui/e2e/ledger-live.spec.ts
+++ b/carboncore-ui/e2e/ledger-live.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Ledger live stream", () => {
+  test("shows new event without refresh", async ({ page }) => {
+    await page.goto("/dashboard");
+    await page.goto("/ledger");
+
+    // Count rows now
+    const initialCount = await page.locator("div[data-row]").count();
+
+    // Trigger fake event (test helper endpoint or fixture)
+    await page.request.post("/api/test/fake-ledger-event");
+
+    // Expect +1 row
+    await expect(page.locator("div[data-row]")).toHaveCount(initialCount + 1, {
+      timeout: 2000
+    });
+  });
+});

--- a/carboncore-ui/lib/auth.ts
+++ b/carboncore-ui/lib/auth.ts
@@ -1,5 +1,5 @@
 import { getServerSession } from "next-auth";
-import type { Role } from "@/types/roles";
+import type { Role } from "@/lib/nav";
 
 export async function getServerSessionWithRole() {
   const session = (await getServerSession()) as (Awaited<ReturnType<typeof getServerSession>> & {

--- a/carboncore-ui/lib/kpi-api.ts
+++ b/carboncore-ui/lib/kpi-api.ts
@@ -1,0 +1,10 @@
+export interface Kpi {
+  label: string;
+  value: number;
+}
+
+export async function fetchKpis(): Promise<Kpi[]> {
+  const res = await fetch("/api/kpi", { cache: "no-store" });
+  if (!res.ok) throw new Error("KPI fetch failed");
+  return res.json();
+}

--- a/carboncore-ui/lib/ledger-api.ts
+++ b/carboncore-ui/lib/ledger-api.ts
@@ -1,0 +1,8 @@
+import { LedgerEvent, LedgerEvent as T } from "@/types/ledger";
+
+export async function fetchLedger(limit = 50): Promise<T[]> {
+  const res = await fetch(`/api/ledger?limit=${limit}`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Ledger fetch failed");
+  const data = await res.json();
+  return LedgerEvent.array().parse(data);
+}

--- a/carboncore-ui/lib/nav.ts
+++ b/carboncore-ui/lib/nav.ts
@@ -1,0 +1,20 @@
+export const NAV_BY_ROLE = {
+  developer: [
+    { href: "/dashboard", label: "Dashboard", icon: "📊" },
+    { href: "/ledger", label: "Ledger", icon: "📜" },
+    { href: "/scheduler", label: "Scheduler", icon: "⏱" }
+  ],
+  finops: [
+    { href: "/dashboard", label: "Dashboard", icon: "📊" },
+    { href: "/ledger", label: "Ledger", icon: "📜" },
+    { href: "/budget", label: "Budget", icon: "💶" }
+  ],
+  sustainability: [
+    { href: "/dashboard", label: "Dashboard", icon: "📊" },
+    { href: "/ledger", label: "Ledger", icon: "📜" },
+    { href: "/reports", label: "Reports", icon: "📄" }
+  ],
+  admin: [{ href: "/settings", label: "Settings", icon: "⚙️" }]
+} as const;
+
+export type Role = keyof typeof NAV_BY_ROLE;

--- a/carboncore-ui/lib/useEventSource.ts
+++ b/carboncore-ui/lib/useEventSource.ts
@@ -1,0 +1,19 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export function useEventSource<T>(url: string) {
+  const [events, setEvents] = useState<T[]>([]);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    const es = new EventSource(url);
+    es.onmessage = (e) => {
+      const payload = JSON.parse(e.data);
+      setEvents((prev) => [payload as T, ...prev]);
+    };
+    esRef.current = es;
+    return () => es.close();
+  }, [url]);
+
+  return events;
+}

--- a/carboncore-ui/types/ledger.ts
+++ b/carboncore-ui/types/ledger.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const LedgerEvent = z.object({
+  id: z.string(),
+  ts: z.string(),
+  project: z.string(),
+  region: z.string(),
+  service: z.string(),
+  kwh: z.number(),
+  co2: z.number(),
+  usd: z.number(),
+  tag: z.string().optional()
+});
+
+export type LedgerEvent = z.infer<typeof LedgerEvent>;


### PR DESCRIPTION
## Summary
- add ledger event types and fetcher
- stream ledger events via EventSource hook
- proxy ledger, stream and KPI APIs
- role-aware navigation in `AppShell`
- simple KPI display on dashboard
- add Playwright e2e spec stub

## Testing
- `pnpm exec vitest run`
- `pnpm exec playwright test` *(fails: ReferenceError: test is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685088e983f883228e19ee2f1d64dc1d