### PR TITLE
Add EcoShift Scheduler v1

### DIFF
--- a/carboncore-ui/app/(protected)/layout.tsx
+++ b/carboncore-ui/app/(protected)/layout.tsx
@@ -1,11 +1,15 @@
 import { ReactNode } from "react";
 import { AuthGuard } from "@/components/AuthGuard";
 import { AppShell } from "@/components/layout/AppShell";
+import { JobStreamToasts } from "@/components/scheduler/JobStreamToasts";
 
 export default function ProtectedLayout({ children }: { children: ReactNode }) {
   return (
     <AuthGuard>
-      <AppShell>{children}</AppShell>
+      <AppShell>
+        {children}
+        <JobStreamToasts />
+      </AppShell>
     </AuthGuard>
   );
 }

--- a/carboncore-ui/app/(protected)/scheduler/page.tsx
+++ b/carboncore-ui/app/(protected)/scheduler/page.tsx
@@ -1,0 +1,20 @@
+import SchedulerCalendar from "@/components/scheduler/Calendar";
+import { fetchJobs } from "@/lib/jobs-api";
+import { startOfWeek, endOfWeek } from "date-fns";
+
+export const dynamic = "force-dynamic";
+
+export default async function SchedulerPage() {
+  const now = new Date();
+  const jobs = await fetchJobs(
+    startOfWeek(now, { weekStartsOn: 1 }).toISOString(),
+    endOfWeek(now, { weekStartsOn: 1 }).toISOString()
+  );
+
+  return (
+    <section>
+      <h1 className="text-2xl font-bold mb-4">EcoShift Scheduler</h1>
+      <SchedulerCalendar jobs={jobs} />
+    </section>
+  );
+}

--- a/carboncore-ui/app/api/jobs/route.ts
+++ b/carboncore-ui/app/api/jobs/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const backendURL = `${process.env.BACKEND_URL}/jobs?${searchParams.toString()}`;
+  const resp = await fetch(backendURL, { headers: { Authorization: req.headers.get("Authorization")! } });
+  return NextResponse.json(await resp.json());
+}
+
+export async function PATCH(req: NextRequest) {
+  const { pathname } = req.nextUrl;           // /api/jobs/123
+  const id = pathname.split("/").pop();
+  const backendURL = `${process.env.BACKEND_URL}/jobs/${id}`;
+  const resp = await fetch(backendURL, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: await req.text()
+  });
+  return NextResponse.json(await resp.json(), { status: resp.status });
+}

--- a/carboncore-ui/app/api/jobs/stream/route.ts
+++ b/carboncore-ui/app/api/jobs/stream/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/jobs/stream`;
+  const resp = await fetch(backendURL, { headers: { Authorization: req.headers.get("Authorization")! } });
+
+  return new NextResponse(resp.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache"
+    }
+  });
+}

--- a/carboncore-ui/app/layout.tsx
+++ b/carboncore-ui/app/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+import { AppToaster } from "@/lib/toast";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <AppToaster />
+      </body>
+    </html>
+  );
+}

--- a/carboncore-ui/components/scheduler/Calendar.tsx
+++ b/carboncore-ui/components/scheduler/Calendar.tsx
@@ -1,0 +1,48 @@
+"use client";
+import FullCalendar from "@fullcalendar/react";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import { Job } from "@/types/job";
+import { useState } from "react";
+import { patchJob } from "@/lib/jobs-api";
+import { toastSuccess, toastError } from "@/lib/toast";
+import { JobTooltip } from "./JobTooltip";
+
+export default function SchedulerCalendar({ jobs }: { jobs: Job[] }) {
+  const [events, setEvents] = useState(() =>
+    jobs.map((j) => ({
+      id: j.id,
+      title: j.project,
+      start: j.start,
+      end: j.end,
+      extendedProps: j
+    }))
+  );
+
+  async function handleDrop(info: any) {
+    const { id } = info.event;
+    const newStart = info.event.start;
+    try {
+      await patchJob(id, { start: newStart.toISOString() });
+      toastSuccess("Job rescheduled to greener slot 👍");
+    } catch (err) {
+      info.revert();
+      toastError("Backend rejected reschedule");
+    }
+  }
+
+  return (
+    <FullCalendar
+      plugins={[timeGridPlugin, interactionPlugin]}
+      initialView="timeGridWeek"
+      allDaySlot={false}
+      nowIndicator
+      editable
+      events={events}
+      eventDrop={handleDrop}
+      eventContent={(arg) => <JobTooltip eventArg={arg} />}
+      height="auto"
+      className="[&_.fc-event]:cursor-move"
+    />
+  );
+}

--- a/carboncore-ui/components/scheduler/JobStreamToasts.tsx
+++ b/carboncore-ui/components/scheduler/JobStreamToasts.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useEventSource } from "@/lib/useEventSource";
+import { toastSuccess } from "@/lib/toast";
+
+interface JobEvent {
+  type: string;
+  message?: string;
+}
+
+export function JobStreamToasts() {
+  const events = useEventSource<JobEvent>("/api/jobs/stream");
+  if (events.length > 0) {
+    const e = events[0];
+    if (e.type === "job_rescheduled") {
+      toastSuccess(e.message || "Job rescheduled");
+    }
+  }
+  return null;
+}

--- a/carboncore-ui/components/scheduler/JobTooltip.tsx
+++ b/carboncore-ui/components/scheduler/JobTooltip.tsx
@@ -1,0 +1,26 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@radix-ui/react-tooltip";
+import { Job } from "@/types/job";
+import { format } from "date-fns";
+
+export function JobTooltip({ eventArg }: { eventArg: any }) {
+  const j = eventArg.event.extendedProps as Job;
+  const pct = j.co2DeltaPct ?? 0;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div>{eventArg.timeText} • {eventArg.event.title}</div>
+      </TooltipTrigger>
+      {pct !== 0 && (
+        <TooltipContent className="bg-cc-base p-3 rounded text-sm">
+          {pct < 0 ? "Move here to cut " : "Moving adds "}
+          {Math.abs(pct)} % CO₂
+          {j.suggestedStart && (
+            <div className="mt-1 text-white/60">
+              Suggested: {format(new Date(j.suggestedStart), "EEE HH:mm")}
+            </div>
+          )}
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+}

--- a/carboncore-ui/e2e/scheduler-dnd.spec.ts
+++ b/carboncore-ui/e2e/scheduler-dnd.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test("drag job & see toast", async ({ page }) => {
+  await page.goto("/scheduler");
+  const event = page.locator(".fc-event").first();
+  const box = await event.boundingBox();
+  // drag 2 hours later (simplified)
+  await page.mouse.move(box!.x + 5, box!.y + 5);
+  await page.mouse.down();
+  await page.mouse.move(box!.x + 5, box!.y + box!.height + 120, { steps: 5 });
+  await page.mouse.up();
+
+  await expect(page.locator(".toast-success")).toHaveText(/rescheduled/, {
+    timeout: 3000
+  });
+});

--- a/carboncore-ui/lib/jobs-api.ts
+++ b/carboncore-ui/lib/jobs-api.ts
@@ -1,0 +1,18 @@
+import { Job } from "@/types/job";
+import qs from "query-string";
+
+export async function fetchJobs(from: string, to: string): Promise<Job[]> {
+  const res = await fetch(`/api/jobs?${qs.stringify({ from, to })}`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Jobs fetch failed");
+  return Job.array().parse(await res.json());
+}
+
+export async function patchJob(id: string, body: Partial<Job>) {
+  const res = await fetch(`/api/jobs/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error("Reschedule failed");
+  return Job.parse(await res.json());
+}

--- a/carboncore-ui/lib/toast.tsx
+++ b/carboncore-ui/lib/toast.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { Toaster, toast } from "sonner";
+
+export const AppToaster = () => <Toaster position="top-right" richColors />;
+
+export const toastSuccess = (msg: string) => toast.success(msg);
+export const toastError = (msg: string) => toast.error(msg);

--- a/carboncore-ui/types/job.ts
+++ b/carboncore-ui/types/job.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const Job = z.object({
+  id: z.string(),
+  project: z.string(),
+  region: z.string(),
+  start: z.string(),   // ISO
+  end: z.string(),     // ISO
+  suggestedStart: z.string().optional(),
+  co2DeltaPct: z.number().optional()   // -40 means 40 % less CO₂
+});
+export type Job = z.infer<typeof Job>;

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
     "openapi:generate": "docker compose exec -T backend curl -s http://localhost:8000/openapi.json | openapi-typescript --stdin --output src/lib/sdk.ts"
   },
   "dependencies": {
+    "@fullcalendar/react": "^6.1.17",
+    "@fullcalendar/timegrid": "^6.1.17",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@fullcalendar/react':
+        specifier: ^6.1.17
+        version: 6.1.17(@fullcalendar/core@6.1.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fullcalendar/timegrid':
+        specifier: ^6.1.17
+        version: 6.1.17(@fullcalendar/core@6.1.17)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -617,6 +623,26 @@ packages:
   '@eslint/plugin-kit@0.3.2':
     resolution: {integrity: sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fullcalendar/core@6.1.17':
+    resolution: {integrity: sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==}
+
+  '@fullcalendar/daygrid@6.1.17':
+    resolution: {integrity: sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.17
+
+  '@fullcalendar/react@6.1.17':
+    resolution: {integrity: sha512-AA8soHhlfRH5dUeqHnfAtzDiXa2vrgWocJSK/F5qzw/pOxc9MqpuoS/nQBROWtHHg6yQUg3DoGqOOhi7dmylXQ==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.17
+      react: ^16.7.0 || ^17 || ^18 || ^19
+      react-dom: ^16.7.0 || ^17 || ^18 || ^19
+
+  '@fullcalendar/timegrid@6.1.17':
+    resolution: {integrity: sha512-K4PlA3L3lclLOs3IX8cvddeiJI9ZVMD7RA9IqaWwbvac771971foc9tFze9YY+Pqesf6S+vhS2dWtEVlERaGlQ==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.17
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4033,6 +4059,9 @@ packages:
     peerDependencies:
       preact: '>=10'
 
+  preact@10.12.1:
+    resolution: {integrity: sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==}
+
   preact@10.26.9:
     resolution: {integrity: sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==}
 
@@ -5380,6 +5409,25 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.0
       levn: 0.4.1
+
+  '@fullcalendar/core@6.1.17':
+    dependencies:
+      preact: 10.12.1
+
+  '@fullcalendar/daygrid@6.1.17(@fullcalendar/core@6.1.17)':
+    dependencies:
+      '@fullcalendar/core': 6.1.17
+
+  '@fullcalendar/react@6.1.17(@fullcalendar/core@6.1.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@fullcalendar/core': 6.1.17
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@fullcalendar/timegrid@6.1.17(@fullcalendar/core@6.1.17)':
+    dependencies:
+      '@fullcalendar/core': 6.1.17
+      '@fullcalendar/daygrid': 6.1.17(@fullcalendar/core@6.1.17)
 
   '@humanfs/core@0.19.1': {}
 
@@ -9008,6 +9056,8 @@ snapshots:
     dependencies:
       preact: 10.26.9
       pretty-format: 3.8.0
+
+  preact@10.12.1: {}
 
   preact@10.26.9: {}
 


### PR DESCRIPTION
## Summary
- implement REST proxy for jobs with SSE streaming
- build interactive calendar with FullCalendar
- enable drag-and-drop rescheduling and success toasts
- connect scheduler page into protected area
- update dependencies for calendar support

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68508c2aa3008322967f4e86282f8c7a