### PR TITLE
Implement Sprint 6 features

### DIFF
--- a/carboncore-ui/app/(protected)/budget/page.tsx
+++ b/carboncore-ui/app/(protected)/budget/page.tsx
@@ -1,0 +1,21 @@
+import { fetchBudget } from "@/lib/budget-api";
+import { BudgetChart } from "@/components/budget/BudgetChart";
+import { BudgetAlertToasts } from "@/components/budget/BudgetAlertToasts";
+import { getServerSessionWithRole } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function BudgetPage() {
+  const session = await getServerSessionWithRole();
+  if (session?.user.role !== "finops") redirect("/dashboard");
+
+  const budget = await fetchBudget();
+  return (
+    <section className="space-y-6">
+      <h1 className="text-2xl font-bold">Carbon Budget Copilot</h1>
+      <BudgetChart initial={budget} />
+      <BudgetAlertToasts />
+    </section>
+  );
+}

--- a/carboncore-ui/app/(protected)/dashboard/page.tsx
+++ b/carboncore-ui/app/(protected)/dashboard/page.tsx
@@ -1,16 +1,35 @@
 import { fetchKpis } from "@/lib/kpi-api";
+import { fetchBudget } from "@/lib/budget-api";
+import { useEventSource } from "@/lib/useEventSource";
 
 export const dynamic = "force-dynamic";
 
 export default async function Dashboard() {
-  const kpis = await fetchKpis();
+  const [kpis, budget] = await Promise.all([fetchKpis(), fetchBudget()]);
+  const last = budget.actual[budget.actual.length - 1];
+  const remaining = budget.budgetEur - last.eur;
   return (
     <section className="grid grid-cols-2 gap-6">
+      <RemainingBudgetTile initial={remaining} />
       {kpis.map((k) => (
         <div key={k.label} className="bg-white/5 rounded p-4">
           {k.label}: {k.value}
         </div>
       ))}
     </section>
+  );
+}
+
+/** Client component */
+function RemainingBudgetTile({ initial }: { initial: number }) {
+  "use client";
+  const ev = useEventSource<{ remaining: number }>("/api/budget/stream");
+  const value = ev[0]?.remaining ?? initial;
+  const danger = value < 0;
+  return (
+    <div className={`rounded p-4 ${danger ? "bg-cc-red animate-pulse" : "bg-white/5"}`}>
+      <p className="text-sm">Remaining budget</p>
+      <p className="text-2xl font-mono">{value.toFixed(0)} €</p>
+    </div>
   );
 }

--- a/carboncore-ui/app/(protected)/settings/page.tsx
+++ b/carboncore-ui/app/(protected)/settings/page.tsx
@@ -1,6 +1,7 @@
 import { SlackForm } from "@/components/settings/SlackForm";
 import { WebhookTable } from "@/components/settings/WebhookTable";
 import { fetchSlackURL, fetchWebhooks } from "@/lib/integrations-api";
+import { FeatureFlagsTable } from "@/components/settings/FeatureFlagsTable";
 
 export const dynamic = "force-dynamic";
 
@@ -18,6 +19,11 @@ export default async function SettingsPage() {
       <div>
         <h2 className="font-semibold mb-2">Webhooks</h2>
         <WebhookTable initial={hooks} />
+      </div>
+
+      <div>
+        <h2 className="font-semibold mb-2">Feature Flags</h2>
+        <FeatureFlagsTable />
       </div>
     </section>
   );

--- a/carboncore-ui/app/api/budget/route.ts
+++ b/carboncore-ui/app/api/budget/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/budget/line`;
+  const resp = await fetch(backendURL, {
+    headers: { Authorization: req.headers.get("Authorization")! }
+  });
+  return NextResponse.json(await resp.json());
+}

--- a/carboncore-ui/app/api/budget/stream/route.ts
+++ b/carboncore-ui/app/api/budget/stream/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const backend = await fetch(`${process.env.BACKEND_URL}/budget/stream`, {
+    headers: { Accept: "text/event-stream" }
+  });
+  if (!backend.body) throw new Error("No stream");
+  return new Response(backend.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache"
+    }
+  });
+}

--- a/carboncore-ui/app/api/flags/route.ts
+++ b/carboncore-ui/app/api/flags/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/flags`;
+  const resp = await fetch(backendURL, { headers: { Authorization: req.headers.get("Authorization")! } });
+  return NextResponse.json(await resp.json());
+}
+
+export async function PATCH(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/flags`;
+  const resp = await fetch(backendURL, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: await req.text()
+  });
+  return NextResponse.json(await resp.json(), { status: resp.status });
+}

--- a/carboncore-ui/app/api/integrations/slack/budget/route.ts
+++ b/carboncore-ui/app/api/integrations/slack/budget/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/integrations/slack/budget`;
+  const resp = await fetch(backendURL, { method: "POST" });
+  return NextResponse.json(await resp.json(), { status: resp.status });
+}

--- a/carboncore-ui/components/budget/BudgetAlertToasts.tsx
+++ b/carboncore-ui/components/budget/BudgetAlertToasts.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEventSource } from "@/lib/useEventSource";
+import { toastError } from "@/lib/toast";
+
+interface AlertEvent {
+  type: string;
+  remaining: number;
+}
+
+export function BudgetAlertToasts() {
+  const events = useEventSource<AlertEvent>("/api/budget/stream");
+  if (events.length > 0) {
+    const e = events[0];
+    if (e.type === "budget_overshoot") {
+      toastError(`Budget exceed by €${Math.round(-e.remaining)}`);
+      fetch("/api/integrations/slack/budget", { method: "POST" });
+    }
+  }
+  return null;
+}

--- a/carboncore-ui/components/budget/BudgetChart.tsx
+++ b/carboncore-ui/components/budget/BudgetChart.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ReferenceLine } from "recharts";
+import { BudgetLine } from "@/types/budget";
+import { useEventSource } from "@/lib/useEventSource";
+import { useEffect, useState } from "react";
+
+export function BudgetChart({ initial }: { initial: BudgetLine }) {
+  const [data, setData] = useState(initial);
+  const updates = useEventSource<BudgetLine>("/api/budget/stream");
+
+  useEffect(() => {
+    if (updates.length) setData(updates[0]);
+  }, [updates]);
+
+  const merged = data.actual.concat(data.forecast);
+
+  return (
+    <LineChart
+      width={800}
+      height={320}
+      data={merged}
+      margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
+      className="mx-auto"
+    >
+      <CartesianGrid stroke="#ccc" strokeDasharray="3 3" />
+      <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+      <YAxis tick={{ fontSize: 12 }} />
+      <Tooltip />
+      <Line type="monotone" dataKey="eur" stroke="#34d399" dot={false} name="Actual" />
+      <Line
+        type="monotone"
+        dataKey="eur"
+        stroke="#fbbf24"
+        dot={false}
+        strokeDasharray="6 6"
+        data={data.forecast}
+        name="Forecast"
+      />
+      <ReferenceLine
+        y={data.budgetEur}
+        stroke="#f87171"
+        strokeDasharray="4 4"
+        label="Budget"
+      />
+    </LineChart>
+  );
+}

--- a/carboncore-ui/components/layout/AppShell.tsx
+++ b/carboncore-ui/components/layout/AppShell.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { ReactNode } from "react";
 import { ModeToggle } from "@/components/ui/ModeToggle";
 import { NAV_BY_ROLE } from "@/lib/nav";
+import { SideNav } from "./SideNav";
 import { getServerSessionWithRole } from "@/lib/auth";
 
 export async function AppShell({ children }: { children: ReactNode }) {
@@ -16,18 +16,7 @@ export async function AppShell({ children }: { children: ReactNode }) {
         <div className="h-16 flex items-center justify-center font-bold">
           CarbonCore
         </div>
-        <nav className="px-4 space-y-1">
-          {nav.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="flex items-center gap-3 px-2 py-2 rounded hover:bg-white/10"
-            >
-              <span>{item.icon}</span>
-              {item.label}
-            </Link>
-          ))}
-        </nav>
+        <SideNav items={nav} />
       </aside>
 
       {/* Main */}

--- a/carboncore-ui/components/layout/SideNav.tsx
+++ b/carboncore-ui/components/layout/SideNav.tsx
@@ -1,0 +1,24 @@
+"use client";
+import Link from "next/link";
+import { useFlags } from "@/lib/useFlags";
+import type { NavItem } from "@/lib/nav";
+
+export function SideNav({ items }: { items: NavItem[] }) {
+  const flags = useFlags();
+  return (
+    <nav className="px-4 space-y-1">
+      {items
+        .filter((i) => (i.flag ? flags[i.flag] : true))
+        .map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="flex items-center gap-3 px-2 py-2 rounded hover:bg-white/10"
+          >
+            <span>{item.icon}</span>
+            {item.label}
+          </Link>
+        ))}
+    </nav>
+  );
+}

--- a/carboncore-ui/components/settings/FeatureFlagsTable.tsx
+++ b/carboncore-ui/components/settings/FeatureFlagsTable.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useFlags } from "@/lib/useFlags";
+import { patchFlag } from "@/lib/flags-api";
+import { Switch } from "@/components/ui/Switch";
+import { toastSuccess, toastError } from "@/lib/toast";
+
+const FLAG_META = [
+  { key: "scheduler", label: "EcoShift Scheduler", role: "developer" },
+  { key: "router", label: "EcoEdge Router", role: "developer" },
+  { key: "budget", label: "Carbon Budget Copilot", role: "finops" }
+] as const;
+
+export function FeatureFlagsTable() {
+  const flags = useFlags();
+
+  async function toggle(key: string, enabled: boolean) {
+    try {
+      await patchFlag(key, enabled);
+      toastSuccess("Flag updated");
+    } catch {
+      toastError("Update failed");
+    }
+  }
+
+  return (
+    <table className="text-sm w-full">
+      <thead>
+        <tr className="text-left text-white/60">
+          <th className="py-2">Feature</th>
+          <th>Role</th>
+          <th>Enabled</th>
+        </tr>
+      </thead>
+      <tbody>
+        {FLAG_META.map((f) => (
+          <tr key={f.key} className="border-t border-white/10">
+            <td className="py-2">{f.label}</td>
+            <td>{f.role}</td>
+            <td>
+              <Switch
+                checked={flags[f.key]}
+                onCheckedChange={(v) => toggle(f.key, v)}
+              />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/carboncore-ui/components/ui/Switch.tsx
+++ b/carboncore-ui/components/ui/Switch.tsx
@@ -1,0 +1,21 @@
+"use client";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+export const Switch = forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-green-500 data-[state=unchecked]:bg-gray-200",
+      className
+    )}
+    {...props}
+  >
+    <SwitchPrimitives.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0" />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = "Switch";

--- a/carboncore-ui/e2e/budget-overshoot.spec.ts
+++ b/carboncore-ui/e2e/budget-overshoot.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test("overshoot alert toast arrives", async ({ page }) => {
+  await page.goto("/budget");
+  await page.request.post("/api/test/trigger-budget-alert");
+  await expect(page.locator(".toast-error")).toContainText(/Budget exceed/, {
+    timeout: 3000
+  });
+});

--- a/carboncore-ui/lib/budget-api.ts
+++ b/carboncore-ui/lib/budget-api.ts
@@ -1,0 +1,7 @@
+import { BudgetLine } from "@/types/budget";
+
+export async function fetchBudget(): Promise<BudgetLine> {
+  const r = await fetch("/api/budget/line", { cache: "no-store" });
+  if (!r.ok) throw new Error("Budget fetch failed");
+  return BudgetLine.parse(await r.json());
+}

--- a/carboncore-ui/lib/flags-api.ts
+++ b/carboncore-ui/lib/flags-api.ts
@@ -1,0 +1,14 @@
+import { Flag } from "@/types/flag";
+
+export async function fetchFlags(): Promise<Flag[]> {
+  const r = await fetch("/api/flags", { cache: "no-store" });
+  return Flag.array().parse(await r.json());
+}
+
+export async function patchFlag(key: string, enabled: boolean) {
+  await fetch(`/api/flags`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, enabled })
+  });
+}

--- a/carboncore-ui/lib/nav.ts
+++ b/carboncore-ui/lib/nav.ts
@@ -1,14 +1,16 @@
-export const NAV_BY_ROLE = {
+export type NavItem = { href: string; label: string; icon: string; flag?: string };
+
+export const NAV_BY_ROLE: Record<string, NavItem[]> = {
   developer: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
-    { href: "/router", label: "Router", icon: "🗺" },
+    { href: "/router", label: "Router", icon: "🗺", flag: "router" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/scheduler", label: "Scheduler", icon: "⏱" }
+    { href: "/scheduler", label: "Scheduler", icon: "⏱", flag: "scheduler" }
   ],
   finops: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/budget", label: "Budget", icon: "💶" }
+    { href: "/budget", label: "Budget", icon: "💶", flag: "budget" }
   ],
   sustainability: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },

--- a/carboncore-ui/lib/useFlags.ts
+++ b/carboncore-ui/lib/useFlags.ts
@@ -1,0 +1,9 @@
+"use client";
+import useSWR from "swr";
+import { fetchFlags } from "./flags-api";
+
+export function useFlags() {
+  const { data: flags = [] } = useSWR("flags", fetchFlags);
+  const map = Object.fromEntries(flags.map((f) => [f.key, f.enabled]));
+  return map as Record<string, boolean>;
+}

--- a/carboncore-ui/types/budget.ts
+++ b/carboncore-ui/types/budget.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const Point = z.object({
+  date: z.string(),
+  tCO2: z.number(),
+  eur: z.number()
+});
+
+export const BudgetLine = z.object({
+  actual: z.array(Point),
+  forecast: z.array(Point),
+  budgetEur: z.number()
+});
+export type BudgetLine = z.infer<typeof BudgetLine>;

--- a/carboncore-ui/types/flag.ts
+++ b/carboncore-ui/types/flag.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const Flag = z.object({
+  key: z.string(),
+  enabled: z.boolean()
+});
+export type Flag = z.infer<typeof Flag>;

--- a/web/src/lib/trendColour.test.ts
+++ b/web/src/lib/trendColour.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { trendColour } from './trendColour';
+
+describe('trendColour', () => {
+  it('returns green for big drop', () => {
+    expect(trendColour(-30)).toBe('text-green-500');
+  });
+  it('returns amber for small change', () => {
+    expect(trendColour(10)).toBe('text-amber-500');
+  });
+  it('returns red for increase', () => {
+    expect(trendColour(50)).toBe('text-red-500');
+  });
+});

--- a/web/src/lib/trendColour.ts
+++ b/web/src/lib/trendColour.ts
@@ -1,0 +1,5 @@
+export function trendColour(delta: number) {
+  if (delta < -20) return "text-green-500";
+  if (delta <= 20) return "text-amber-500";
+  return "text-red-500";
+}


### PR DESCRIPTION
## Summary
- add Carbon Budget Copilot page with live chart
- display remaining budget KPI on dashboard
- provide Feature Flags console in Settings
- proxy backend endpoints for budget and flags
- enable runtime nav flags and alert toasts
- add trendColour util with unit tests

## Testing
- `make test` *(fails: Poetry could not find a pyproject.toml)*
- `pnpm --dir web test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850949bad4083229646fa2efe68ae41