### PR TITLE
Add SupplyCarbon pulse and offset autopilot

### DIFF
--- a/carboncore-ui/app/api/offsets/ledger/route.ts
+++ b/carboncore-ui/app/api/offsets/ledger/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/offsets/ledger`;
+  const resp = await fetch(backendURL, {
+    headers: { Authorization: req.headers.get("Authorization")! }
+  });
+  return NextResponse.json(await resp.json());
+}

--- a/carboncore-ui/app/api/offsets/residual/route.ts
+++ b/carboncore-ui/app/api/offsets/residual/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/offsets/residual`;
+  const resp = await fetch(backendURL, {
+    headers: { Authorization: req.headers.get("Authorization")! }
+  });
+  return NextResponse.json(await resp.json());
+}

--- a/carboncore-ui/app/api/offsets/stream/route.ts
+++ b/carboncore-ui/app/api/offsets/stream/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const { readable, writable } = new TransformStream();
+  const backend = await fetch(`${process.env.BACKEND_URL}/offsets/stream`, {
+    headers: { Accept: "text/event-stream" }
+  });
+  if (!backend.body) throw new Error("No stream");
+  backend.body.pipeTo(writable);
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache"
+    }
+  });
+}

--- a/carboncore-ui/app/api/offsets/threshold/route.ts
+++ b/carboncore-ui/app/api/offsets/threshold/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/offsets/threshold`;
+  const resp = await fetch(backendURL, {
+    headers: { Authorization: req.headers.get("Authorization")! }
+  });
+  return NextResponse.json(await resp.json());
+}
+
+export async function PATCH(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/offsets/threshold`;
+  const resp = await fetch(backendURL, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: await req.text()
+  });
+  return NextResponse.json(await resp.json(), { status: resp.status });
+}

--- a/carboncore-ui/app/api/vendors/[id]/email/route.ts
+++ b/carboncore-ui/app/api/vendors/[id]/email/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const backendURL = `${process.env.BACKEND_URL}/vendors/${params.id}/email`;
+  const resp = await fetch(backendURL, { method: "POST" });
+  return NextResponse.json(await resp.json(), { status: resp.status });
+}

--- a/carboncore-ui/app/api/vendors/route.ts
+++ b/carboncore-ui/app/api/vendors/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const backendURL = `${process.env.BACKEND_URL}/vendors`;
+  const resp = await fetch(backendURL, {
+    headers: { Authorization: req.headers.get("Authorization")! }
+  });
+  return NextResponse.json(await resp.json());
+}

--- a/carboncore-ui/app/api/vendors/stream/route.ts
+++ b/carboncore-ui/app/api/vendors/stream/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const { readable, writable } = new TransformStream();
+  const backend = await fetch(`${process.env.BACKEND_URL}/vendors/stream`, {
+    headers: { Accept: "text/event-stream" }
+  });
+  if (!backend.body) throw new Error("No stream");
+  backend.body.pipeTo(writable);
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache"
+    }
+  });
+}

--- a/carboncore-ui/app/org/[orgId]/offsets/page.tsx
+++ b/carboncore-ui/app/org/[orgId]/offsets/page.tsx
@@ -1,0 +1,17 @@
+import { ThresholdSlider } from "@/components/offsets/ThresholdSlider";
+import { NetZeroGauge } from "@/components/offsets/NetZeroGauge";
+import { OffsetLedgerTable } from "@/components/offsets/OffsetLedgerTable";
+import { fetchThreshold, fetchResidual } from "@/lib/offsets-api";
+
+export const dynamic = "force-dynamic";
+export default async function OffsetsPage() {
+  const [th, residual] = await Promise.all([fetchThreshold(), fetchResidual()]);
+  return (
+    <section className="space-y-6">
+      <h1 className="text-2xl font-bold">OffsetSync Autopilot</h1>
+      <ThresholdSlider initial={th} />
+      <NetZeroGauge initial={residual} />
+      <OffsetLedgerTable />
+    </section>
+  );
+}

--- a/carboncore-ui/app/org/[orgId]/pulse/page.tsx
+++ b/carboncore-ui/app/org/[orgId]/pulse/page.tsx
@@ -1,0 +1,12 @@
+import { VendorTable } from "@/components/pulse/VendorTable";
+import { PulseAlertToasts } from "@/components/pulse/PulseAlertToasts";
+
+export default function SupplyCarbonPulsePage() {
+  return (
+    <section className="space-y-6">
+      <h1 className="text-2xl font-bold">SupplyCarbon Pulse</h1>
+      <VendorTable />
+      <PulseAlertToasts />
+    </section>
+  );
+}

--- a/carboncore-ui/components/dashboard/GaugeCanvas.tsx
+++ b/carboncore-ui/components/dashboard/GaugeCanvas.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+export function GaugeCanvas({ value, dangerThreshold, unit }: { value: number; dangerThreshold: number; unit: string }) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const c = ref.current;
+    if (!c) return;
+    const ctx = c.getContext("2d")!;
+    ctx.clearRect(0, 0, c.width, c.height);
+    ctx.lineWidth = 8;
+    ctx.strokeStyle = value > dangerThreshold ? "#34d399" : "#f87171";
+    ctx.beginPath();
+    ctx.arc(50, 50, 40, Math.PI, Math.PI + (value / 100) * Math.PI, false);
+    ctx.stroke();
+  }, [value, dangerThreshold]);
+
+  return (
+    <div className="w-24 text-center">
+      <canvas ref={ref} width={100} height={60} />
+      <p className="text-xs mt-1">
+        {value.toFixed(1)} {unit}
+      </p>
+    </div>
+  );
+}

--- a/carboncore-ui/components/offsets/NetZeroGauge.tsx
+++ b/carboncore-ui/components/offsets/NetZeroGauge.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { GaugeCanvas } from "@/components/dashboard/GaugeCanvas";
+import { useEventSource } from "@/lib/useEventSource";
+
+export function NetZeroGauge({ initial }: { initial: number }) {
+  const ev = useEventSource<{ residual: number }>("/api/offsets/stream");
+  const residual = ev[0]?.residual ?? initial;
+  return <GaugeCanvas value={residual} dangerThreshold={0} unit="t CO₂" />;
+}

--- a/carboncore-ui/components/offsets/OffsetLedgerTable.tsx
+++ b/carboncore-ui/components/offsets/OffsetLedgerTable.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { OffsetPurchase } from "@/types/offset";
+import useSWR from "swr";
+import { fetchLedger } from "@/lib/offsets-api";
+
+const fetcher = () => fetchLedger();
+
+export function OffsetLedgerTable() {
+  const { data: rows = [] } = useSWR<OffsetPurchase[]>("/api/offsets/ledger", fetcher, {
+    refreshInterval: 60_000
+  });
+
+  return (
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="text-left text-white/60">
+          <th className="py-2">Date</th>
+          <th>Tonnes</th>
+          <th>Project</th>
+          <th>Cert hash</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={i} className="border-t border-white/10">
+            <td className="py-2">{r.date.slice(0, 10)}</td>
+            <td>{r.tonnes.toFixed(2)}</td>
+            <td>{r.project}</td>
+            <td className="font-mono text-xs">{r.certHash.slice(0, 8)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/carboncore-ui/components/offsets/ThresholdSlider.tsx
+++ b/carboncore-ui/components/offsets/ThresholdSlider.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { Slider } from "@/components/ui/Slider";
+import { useState } from "react";
+import { saveThreshold } from "@/lib/offsets-api";
+import { toastSuccess } from "@/lib/toast";
+
+export function ThresholdSlider({ initial }: { initial: number }) {
+  const [v, setV] = useState(initial);
+
+  async function commit([val]: number[]) {
+    setV(val);
+    await saveThreshold(val);
+    toastSuccess("Threshold saved");
+  }
+
+  return (
+    <div className="max-w-md">
+      <p className="mb-2 text-sm">Auto-purchase when residual tCO₂ &gt;</p>
+      <Slider defaultValue={[v]} step={1} min={5} max={50} onValueCommit={commit} />
+      <p className="mt-1 text-xs">{v} t CO₂</p>
+    </div>
+  );
+}

--- a/carboncore-ui/components/pulse/PulseAlertToasts.tsx
+++ b/carboncore-ui/components/pulse/PulseAlertToasts.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useEventSource } from "@/lib/useEventSource";
+import { toastError } from "@/lib/toast";
+
+interface AlertEvent {
+  vendor: string;
+  type: string;
+}
+
+export function PulseAlertToasts() {
+  const events = useEventSource<AlertEvent>("/api/vendors/stream");
+  if (events.length > 0) {
+    const e = events[0];
+    if (e.type === "breach") {
+      toastError(`${e.vendor} breached SLA`);
+    }
+  }
+  return null;
+}

--- a/carboncore-ui/components/pulse/VendorModal.tsx
+++ b/carboncore-ui/components/pulse/VendorModal.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { Vendor } from "@/types/vendor";
+import { Dialog } from "@headlessui/react";
+import { Line } from "react-chartjs-2";
+import { Button } from "@/components/ui/Button";
+import { toastSuccess, toastError } from "@/lib/toast";
+
+export function VendorModal({ v, onClose }: { v: Vendor; onClose: () => void }) {
+  async function handleEmail() {
+    const r = await fetch(`/api/vendors/${v.id}/email`, { method: "POST" });
+    r.ok ? toastSuccess("Remediation email sent") : toastError("Failed");
+  }
+
+  return (
+    <Dialog open onClose={onClose} className="fixed inset-0 grid place-items-center">
+      <Dialog.Panel className="bg-cc-base p-6 rounded max-w-lg w-full">
+        <Dialog.Title className="text-lg font-bold mb-4">{v.name}</Dialog.Title>
+        {/* placeholder sparkline */}
+        <Line
+          data={{
+            labels: Array(30).fill(""),
+            datasets: [
+              {
+                data: Array(30)
+                  .fill(0)
+                  .map(() => Math.random()),
+                borderColor: "#34d399"
+              }
+            ]
+          }}
+          options={{
+            plugins: { legend: { display: false } },
+            scales: { x: { display: false }, y: { display: false } }
+          }}
+          height={80}
+        />
+        <div className="mt-6 flex justify-end gap-4">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+          <Button variant="secondary" onClick={handleEmail}>
+            Send remediation email
+          </Button>
+        </div>
+      </Dialog.Panel>
+    </Dialog>
+  );
+}

--- a/carboncore-ui/components/pulse/VendorTable.tsx
+++ b/carboncore-ui/components/pulse/VendorTable.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { Vendor } from "@/types/vendor";
+import useSWR from "swr";
+import { isBreach } from "@/lib/breach-util";
+import { VendorModal } from "./VendorModal";
+import { useState } from "react";
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+export function VendorTable() {
+  const { data: vendors = [] } = useSWR<Vendor[]>("/api/vendors", fetcher, {
+    refreshInterval: 3600_000
+  });
+  const [modal, setModal] = useState<Vendor | null>(null);
+
+  return (
+    <>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-white/60">
+            <th className="py-2">Vendor</th>
+            <th>Endpoint</th>
+            <th>CO₂/1k</th>
+            <th>Last check</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vendors.map((v) => (
+            <tr
+              key={v.id}
+              className="border-t border-white/10 hover:bg-white/5 cursor-pointer"
+              onClick={() => setModal(v)}
+            >
+              <td className="py-2 flex items-center gap-2">
+                {v.name}
+                {isBreach(v) && (
+                  <span className="px-2 rounded bg-cc-red text-xs">⚠ breach</span>
+                )}
+              </td>
+              <td>{new URL(v.endpoint).host}</td>
+              <td>{v.kgCo2PerK.toFixed(2)} kg</td>
+              <td>{v.lastCheck.slice(0, 10)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {modal && <VendorModal v={modal} onClose={() => setModal(null)} />}
+    </>
+  );
+}

--- a/carboncore-ui/e2e/vendor-breach.spec.ts
+++ b/carboncore-ui/e2e/vendor-breach.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test("breach toast appears", async ({ page }) => {
+  await page.goto("/org/acme/pulse");
+  await page.request.post("/api/test/vendor-breach");
+  await expect(page.locator(".toast-error, .toast-success")).toHaveText(/breached SLA/, {
+    timeout: 3000
+  });
+});

--- a/carboncore-ui/lib/breach-util.ts
+++ b/carboncore-ui/lib/breach-util.ts
@@ -1,0 +1,4 @@
+export const BREACH_LIMIT = 0.5; // kg CO₂ / 1 000 req
+export function isBreach(v: { kgCo2PerK: number }) {
+  return v.kgCo2PerK > BREACH_LIMIT;
+}

--- a/carboncore-ui/lib/offsets-api.ts
+++ b/carboncore-ui/lib/offsets-api.ts
@@ -1,0 +1,30 @@
+import { OffsetPurchase } from "@/types/offset";
+
+export async function fetchLedger(): Promise<OffsetPurchase[]> {
+  const r = await fetch("/api/offsets/ledger", { cache: "no-store" });
+  if (!r.ok) throw new Error("Ledger fetch failed");
+  return OffsetPurchase.array().parse(await r.json());
+}
+
+export async function fetchThreshold(): Promise<number> {
+  const r = await fetch("/api/offsets/threshold", { cache: "no-store" });
+  if (!r.ok) throw new Error("Threshold fetch failed");
+  const d = await r.json();
+  return d.value as number;
+}
+
+export async function saveThreshold(v: number) {
+  const r = await fetch("/api/offsets/threshold", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value: v })
+  });
+  if (!r.ok) throw new Error("Save failed");
+}
+
+export async function fetchResidual(): Promise<number> {
+  const r = await fetch("/api/offsets/residual", { cache: "no-store" });
+  if (!r.ok) throw new Error("Residual fetch failed");
+  const d = await r.json();
+  return d.value as number;
+}

--- a/carboncore-ui/lib/vendor-api.ts
+++ b/carboncore-ui/lib/vendor-api.ts
@@ -1,0 +1,12 @@
+import { Vendor } from "@/types/vendor";
+
+export async function fetchVendors(): Promise<Vendor[]> {
+  const r = await fetch("/api/vendors", { cache: "no-store" });
+  if (!r.ok) throw new Error("Vendor fetch failed");
+  return Vendor.array().parse(await r.json());
+}
+
+export async function sendRemediationEmail(id: string) {
+  const r = await fetch(`/api/vendors/${id}/email`, { method: "POST" });
+  if (!r.ok) throw new Error("Email failed");
+}

--- a/carboncore-ui/types/offset.ts
+++ b/carboncore-ui/types/offset.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+export const OffsetPurchase = z.object({
+  date: z.string(),
+  tonnes: z.number(),
+  project: z.string(),
+  certHash: z.string()
+});
+export type OffsetPurchase = z.infer<typeof OffsetPurchase>;

--- a/carboncore-ui/types/vendor.ts
+++ b/carboncore-ui/types/vendor.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+export const Vendor = z.object({
+  id: z.string(),
+  name: z.string(),
+  endpoint: z.string(),
+  kgCo2PerK: z.number(),
+  lastCheck: z.string(),
+  breach: z.boolean()
+});
+export type Vendor = z.infer<typeof Vendor>;


### PR DESCRIPTION
## Summary
- implement Sprint 8 features for SupplyCarbon Pulse and OffsetSync Autopilot
- add vendor and offset types and API helpers
- proxy vendor and offset endpoints
- add pulse table/modal with SSE alerts
- add offset threshold slider, gauge and ledger table
- create E2E spec for vendor breach

## Testing
- `make test` *(fails: Poetry could not find a pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68509952412c8322ae35cd8d0551ecbe