### PR TITLE
Fix flags URL and update virtual table

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,7 +7,8 @@ import { Shell } from "@/components/Shell";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
-export const metadata = { title: "CarbonCore Console", viewport: "width=device-width, initial-scale=1" };
+export const metadata = { title: "CarbonCore Console" };
+export const viewport = { width: 1024, initialScale: 1.0 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/frontend/app/org/[orgId]/dashboard/page.tsx
+++ b/frontend/app/org/[orgId]/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { request } from '@/lib/request';
+import { fetchKpis } from '@/lib/kpi-api';
 import { getActiveOrgId } from '@/lib/org';
 import { notFound } from 'next/navigation';
 
@@ -11,7 +11,7 @@ export default async function Dashboard({
 }) {
   const orgId = getActiveOrgId(params.orgId);
   if (!orgId) notFound();
-  const kpis = await request(`/api/org/${orgId}/kpi`);
+  const kpis = await fetchKpis(orgId);
 
   return (
     <div className="space-y-6">

--- a/frontend/components/VirtualTable.tsx
+++ b/frontend/components/VirtualTable.tsx
@@ -1,30 +1,36 @@
-import { FixedSizeList as List, ListChildComponentProps } from 'react-virtualized';
-import clsx from 'clsx';
+'use client';
+
+import { FixedSizeList as List } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+
+export type RowRendererProps = {
+  index: number;
+  style: React.CSSProperties;
+};
 
 export function VirtualTable<T>({
-  rowHeight = 40,
-  height = 600,
-  rowClassName,
-  rowRenderer,
+  height = 400,
+  rowHeight = 32,
   items,
+  renderRow,
 }: {
-  rowHeight?: number;
   height?: number;
-  rowClassName?: (index: number) => string;
-  rowRenderer: (item: T, index: number) => React.ReactNode;
+  rowHeight?: number;
   items: T[];
+  renderRow: (item: T, row: RowRendererProps) => React.ReactNode;
 }) {
   return (
-    <List
-      height={height}
-      rowHeight={rowHeight}
-      rowCount={items.length}
-      width={'100%'}
-      rowRenderer={({ index, key, style }: ListChildComponentProps) => (
-        <div key={key} style={style} className={clsx('px-2', rowClassName?.(index))}>
-          {rowRenderer(items[index], index)}
-        </div>
+    <AutoSizer disableHeight>
+      {({ width }) => (
+        <List
+          width={width}
+          height={height}
+          itemCount={items.length}
+          itemSize={rowHeight}
+        >
+          {({ index, style }) => renderRow(items[index], { index, style })}
+        </List>
       )}
-    />
+    </AutoSizer>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "react-leaflet": "^5.0.0",
     "react-use": "^17.6.0",
     "react-virtualized": "^9.22.6",
+    "react-window": "^1.8.11",
     "recharts": "^2.15.3",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react-virtualized:
         specifier: ^9.22.6
         version: 9.22.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-window:
+        specifier: ^1.8.11
+        version: 1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.15.3
         version: 2.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3316,6 +3319,9 @@ packages:
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
@@ -3839,6 +3845,13 @@ packages:
     peerDependencies:
       react: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-window@1.8.11:
+    resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -7766,6 +7779,8 @@ snapshots:
 
   mdn-data@2.0.14: {}
 
+  memoize-one@5.2.1: {}
+
   memoizerific@1.11.3:
     dependencies:
       map-or-similar: 1.5.0
@@ -8309,6 +8324,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-lifecycles-compat: 3.0.4
+
+  react-window@1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      memoize-one: 5.2.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -4,7 +4,7 @@ export type { Role } from './auth.server';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export async function getRole() {
   if (process.env.NODE_ENV !== 'production') {
-    console.warn('getRole() invoked in the browser. Returning "analyst".');
+    console.debug('getRole() invoked in the browser. Returning "analyst".');
   }
   return 'analyst';
 }

--- a/frontend/src/lib/flags-api.ts
+++ b/frontend/src/lib/flags-api.ts
@@ -1,8 +1,8 @@
 import type { Flag } from "@/types/flag";
-import { request } from './request';
+import { request } from '@/lib/request';
 
 export async function fetchFlags(orgId: string): Promise<Flag[]> {
-  return request("/org/{orgId}/flags", "get", { orgId }) as Promise<Flag[]>;
+  return request(`/api/org/${orgId}/flags`);
 }
 
 export async function patchFlag(key: string, enabled: boolean) {

--- a/frontend/src/lib/useFlags.ts
+++ b/frontend/src/lib/useFlags.ts
@@ -5,7 +5,6 @@ import type { Flag } from "@/types/flag";
 export function useFlags(orgId: string) {
   return useQuery({
     queryKey: ["flags", orgId],
-    queryFn: () =>
-      request("/org/{orgId}/flags", "get", { orgId }) as Promise<Flag[]>,
+    queryFn: () => request(`/api/org/${orgId}/flags`) as Promise<Flag[]>,
   });
 }


### PR DESCRIPTION
## Summary
- define viewport at root layout
- fix flags API path
- update flags hook
- rewrite VirtualTable using `react-window`
- fetch KPIs inside the org dashboard page
- quiet browser `getRole()` warnings
- add `react-window` dependency

## Testing
- `pnpm lint` *(fails: @typescript-eslint/no-unused-vars, tailwindcss warnings, parsing errors)*
- `pnpm test` *(fails to run due to setup errors)*
- `pnpm exec tsc --noEmit` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857364eba248322b9d09107a87f5b65