### PR TITLE
Fix SSE handling and restore API proxying

### DIFF
--- a/frontend/components/budget/BudgetChart.tsx
+++ b/frontend/components/budget/BudgetChart.tsx
@@ -6,11 +6,13 @@ import { useEffect, useState } from "react";
 
 export function BudgetChart({ initial }: { initial: BudgetLine }) {
   const [data, setData] = useState(initial);
-  const updates = useEventSource<BudgetLine>("/api/budget/stream");
+  const [evt] = useEventSource<BudgetLine>("/api/proxy/budget/stream", {
+    reconnect: true,
+  });
 
   useEffect(() => {
-    if (updates.length) setData(updates[0]);
-  }, [updates]);
+    if (evt) setData(evt);
+  }, [evt]);
 
   const merged = data.actual.concat(data.forecast);
 

--- a/frontend/components/budget/BudgetView.tsx
+++ b/frontend/components/budget/BudgetView.tsx
@@ -13,11 +13,14 @@ export default function BudgetView({
   orgId: string;
 }) {
   const [data, setData] = useState(initial);
-
-  useEventSource<BudgetLine>(
+  const [evt] = useEventSource<BudgetLine>(
     `/api/proxy/org/${orgId}/budget/stream`,
-    (e) => setData(e)
+    { reconnect: true }
   );
+
+  useEffect(() => {
+    if (evt) setData(evt);
+  }, [evt]);
 
   return (
     <div className="space-y-6">

--- a/frontend/components/offsets/NetZeroGauge.tsx
+++ b/frontend/components/offsets/NetZeroGauge.tsx
@@ -3,7 +3,9 @@ import { GaugeCanvas } from "@/components/dashboard/GaugeCanvas";
 import { useEventSource } from "@/lib/useEventSource";
 
 export function NetZeroGauge({ initial }: { initial: number }) {
-  const ev = useEventSource<{ residual: number }>("/api/offsets/stream");
+  const ev = useEventSource<{ residual: number }>("/api/proxy/offsets/stream", {
+    reconnect: true,
+  });
   const residual = ev[0]?.residual ?? initial;
   return <GaugeCanvas value={residual} dangerThreshold={0} unit="t CO₂" />;
 }

--- a/frontend/components/offsets/OffsetLedger.tsx
+++ b/frontend/components/offsets/OffsetLedger.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEventSource } from "@/lib/useEventSource";
 import { OffsetPurchase } from "@/types/offset";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function OffsetLedger({
   initial,
@@ -10,12 +10,15 @@ export default function OffsetLedger({
   initial: OffsetPurchase[];
   orgId: string;
 }) {
-  const [rows, setRows] = useState(initial);
-
-  useEventSource<OffsetPurchase>(
+  const [rows, setRows] = useState<OffsetPurchase[]>(initial ?? []);
+  const [evt] = useEventSource<OffsetPurchase>(
     `/api/proxy/org/${orgId}/offsets/stream`,
-    (e) => setRows((r) => [e, ...r])
+    { reconnect: true }
   );
+
+  useEffect(() => {
+    if (evt) setRows((r) => [evt, ...r]);
+  }, [evt]);
 
   return (
     <table className="w-full text-sm border-collapse">

--- a/frontend/components/pulse/PulseAlertToasts.tsx
+++ b/frontend/components/pulse/PulseAlertToasts.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEventSource } from "@/lib/useEventSource";
 import { toastError } from "@/lib/toast";
+import { useEffect } from "react";
 
 interface AlertEvent {
   vendor: string;
@@ -8,12 +9,16 @@ interface AlertEvent {
 }
 
 export function PulseAlertToasts() {
-  const events = useEventSource<AlertEvent>("/api/vendors/stream");
-  if (events.length > 0) {
-    const e = events[0];
-    if (e.type === "breach") {
-      toastError(`${e.vendor} breached SLA`);
+  const [evt] = useEventSource<AlertEvent>("/api/proxy/vendors/stream", {
+    reconnect: true,
+  });
+
+  useEffect(() => {
+    if (!evt) return;
+    if (evt.type === "breach") {
+      toastError(`${evt.vendor} breached SLA`);
     }
-  }
+  }, [evt]);
+
   return null;
 }

--- a/frontend/components/pulse/VendorModal.tsx
+++ b/frontend/components/pulse/VendorModal.tsx
@@ -7,7 +7,7 @@ import { toastSuccess, toastError } from "@/lib/toast";
 
 export function VendorModal({ v, onClose }: { v: Vendor; onClose: () => void }) {
   async function handleEmail() {
-    const r = await fetch(`/api/vendors/${v.id}/email`, { method: "POST" });
+    const r = await fetch(`/api/proxy/vendors/${v.id}/email`, { method: "POST" });
     r.ok ? toastSuccess("Remediation email sent") : toastError("Failed");
   }
 

--- a/frontend/components/pulse/VendorTable.tsx
+++ b/frontend/components/pulse/VendorTable.tsx
@@ -3,7 +3,7 @@ import { Vendor } from "@/types/vendor";
 import { useEventSource } from "@/lib/useEventSource";
 import { isBreach } from "@/lib/breach-util";
 import { VendorModal } from "./VendorModal";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function VendorTable({
   initial,
@@ -12,13 +12,17 @@ export default function VendorTable({
   initial: Vendor[];
   orgId: string;
 }) {
-  const [vendors, setVendors] = useState(initial);
+  const [vendors, setVendors] = useState<Vendor[]>(initial ?? []);
   const [modal, setModal] = useState<Vendor | null>(null);
 
-  useEventSource<Vendor>(
+  const [evt] = useEventSource<Vendor>(
     `/api/proxy/org/${orgId}/vendors/stream`,
-    (v) => setVendors((r) => [v, ...r])
+    { reconnect: true }
   );
+
+  useEffect(() => {
+    if (evt) setVendors((r) => [evt, ...r]);
+  }, [evt]);
 
   return (
     <>

--- a/frontend/components/scheduler/Calendar.tsx
+++ b/frontend/components/scheduler/Calendar.tsx
@@ -8,9 +8,10 @@ import { patchJob } from "@/lib/jobs-api";
 import { toastSuccess, toastError } from "@/lib/toast";
 import { JobTooltip } from "./JobTooltip";
 
-export default function SchedulerCalendar({ jobs }: { jobs: Job[] }) {
+export default function SchedulerCalendar({ jobs }: { jobs?: Job[] }) {
+  const safe = Array.isArray(jobs) ? jobs : [];
   const [events, setEvents] = useState(() =>
-    jobs.map((j) => ({
+    safe.map((j) => ({
       id: j.id,
       title: j.project,
       start: j.start,

--- a/frontend/components/scheduler/JobStreamToasts.tsx
+++ b/frontend/components/scheduler/JobStreamToasts.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEventSource } from "@/lib/useEventSource";
 import { toastSuccess } from "@/lib/toast";
+import { useEffect } from "react";
 
 interface JobEvent {
   type: string;
@@ -8,12 +9,16 @@ interface JobEvent {
 }
 
 export function JobStreamToasts() {
-  const events = useEventSource<JobEvent>("/api/jobs/stream");
-  if (events.length > 0) {
-    const e = events[0];
-    if (e.type === "job_rescheduled") {
-      toastSuccess(e.message || "Job rescheduled");
+  const [evt] = useEventSource<JobEvent>("/api/proxy/jobs/stream", {
+    reconnect: true,
+  });
+
+  useEffect(() => {
+    if (!evt) return;
+    if (evt.type === "job_rescheduled") {
+      toastSuccess(evt.message || "Job rescheduled");
     }
-  }
+  }, [evt]);
+
   return null;
 }

--- a/frontend/components/scheduler/SchedulerView.tsx
+++ b/frontend/components/scheduler/SchedulerView.tsx
@@ -2,15 +2,17 @@
 import SchedulerCalendar from "./Calendar";
 import { Job } from "@/types/job";
 import { useEventSource } from "@/lib/useEventSource";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function SchedulerView({ initial, orgId }: { initial: Job[]; orgId: string }) {
-  const [jobs, setJobs] = useState(initial);
+  const [jobs, setJobs] = useState<Job[]>(initial ?? []);
+  const [evt] = useEventSource<Job>(`/api/proxy/org/${orgId}/jobs/stream`, {
+    reconnect: true,
+  });
 
-  useEventSource<Job>(
-    `/api/proxy/org/${orgId}/jobs/stream`,
-    (j) => setJobs((prev) => [j, ...prev])
-  );
+  useEffect(() => {
+    if (evt) setJobs((prev) => [evt, ...prev]);
+  }, [evt]);
 
   return <SchedulerCalendar jobs={jobs} />;
 }

--- a/frontend/components/settings/WebhookTable.tsx
+++ b/frontend/components/settings/WebhookTable.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { toastError, toastSuccess } from "@/lib/toast";
 
-export function WebhookTable({ initial }: { initial: Webhook[] }) {
-  const [hooks, setHooks] = useState(initial);
+export function WebhookTable({ initial }: { initial?: Webhook[] }) {
+  const [hooks, setHooks] = useState<Webhook[]>(() => Array.isArray(initial) ? initial : []);
   const [url, setUrl] = useState("");
 
   async function add() {


### PR DESCRIPTION
## Summary
- restore proxy rewrites in Next config so `/api/proxy/*` hits the backend
- update budget, scheduler and vendor components to use `useEffect` for side effects
- switch SSE endpoints to `/api/proxy/*` and ensure reconnect logic
- guard list components against undefined props
- extend `useEventSource` with callback API

## Testing
- `./scripts/smoke-build.sh` *(fails: ModuleNotFoundError: No module named 'celery')*
- `pnpm lint` *(fails: missing ESLint plugin setup)*
- `pnpm build` *(fails: unable to fetch fonts and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6857e565c1888322a324c0a88aa38091