### PR TITLE
Add IaC Advisor plugin and frontend

### DIFF
--- a/.github/workflows/iac-advisor.yml
+++ b/.github/workflows/iac-advisor.yml
@@ -1,0 +1,42 @@
+name: IaC Advisor
+
+on:
+  pull_request: { types: [opened, synchronize, reopened] }
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v2
+        with: { terraform_wrapper: false }
+
+      - name: gen plan
+        run: |
+          terraform init -input=false
+          terraform plan -out=plan.tfplan || true
+          terraform show -json plan.tfplan > plan.json || echo '{}' > plan.json
+
+      - name: call advisor
+        env:
+          URL: ${{ secrets.CARBONCORE_API_URL }}
+          TOK: ${{ secrets.CARBONCORE_API_TOKEN }}
+        run: |
+          curl -s -X POST "$URL/iac-advisor/analyze" \
+               -H"x-project-token:$TOK" \
+               -H"Content-Type: application/json" \
+               --data-binary @plan.json > out.json
+
+      - name: comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs=require('fs')
+            const body=JSON.parse(fs.readFileSync('out.json','utf8'))
+            if(!body.suggestions||!body.suggestions.length) return
+            let md="### IaC Advisor Suggestions\n"
+            for(const s of body.suggestions){
+              md+=`* **${s.resource}**: \`${s.current}\` → \`${s.suggestion}\`  (saves ~${s.co2_saved_kg_per_day} kg CO₂ / $${s.cost_saved_usd_per_day}/day)\n`
+            }
+            github.rest.issues.createComment({ ...context.repo, issue_number:context.issue.number, body:md })

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -1,27 +1,17 @@
-from typing import Dict
+from app.schemas.plugins import PluginManifest, Route
 
-from app.schemas.plugins import PluginManifest
-from plugins.ecoshift.manifest import manifest as eco_shift_manifest
-from plugins.pulse.manifest import manifest as supply_pulse_manifest
-from plugins.ecolabel.manifest import manifest as eco_label_manifest
-from plugins.core.manifest import manifest as core_manifest
-from plugins.budget.manifest import manifest as budget_copilot_manifest
-from plugins.carboncomply.manifest import manifest as carbon_comply_manifest
-from plugins.greendev.manifest import manifest as green_dev_manifest
-from plugins.edge_router.manifest import manifest as edge_router_manifest
-from plugins.offset_sync.manifest import manifest as offset_sync_manifest
-
-REGISTRY: Dict[str, PluginManifest] = {
-    "eco-shift": eco_shift_manifest,
-    "supply-pulse": supply_pulse_manifest,
-    "eco-label": eco_label_manifest,
-    "core": core_manifest,
-    "budget-copilot": budget_copilot_manifest,
-    "carbon-comply": carbon_comply_manifest,
-    "green-dev": green_dev_manifest,
-    "edge-router": edge_router_manifest,
-    "offset-sync": offset_sync_manifest,
+REGISTRY: dict[str, PluginManifest] = {
+    "budget-copilot": PluginManifest(**{'id': 'budget-copilot', 'event_types': ['budget_forecast', 'budget_overshoot'], 'routes': [{'handler': 'plugins.budget.budget.views:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'mount_point': None, 'schedules': [{'name': 'budget.forecast', 'task': 'plugins.budget.budget.forecast:hourly', 'every': 3600, 'cron': None}, {'name': 'budget.overshoot', 'task': 'plugins.budget.budget.alert:overshoot', 'every': 3600, 'cron': None}]}),
+    "carbon-comply": PluginManifest(**{'id': 'carbon-comply', 'event_types': ['comply_export'], 'routes': [{'handler': 'plugins.carboncomply.carboncomply.views:export_xlsx', 'path': '/comply/xlsx', 'method': 'GET', 'prefix': None}], 'mount_point': None, 'schedules': [{'name': 'offset.alert', 'task': 'plugins.carboncomply.carboncomply.alert:notify', 'every': 43200, 'cron': None}]}),
+    "core": PluginManifest(**{'id': 'core', 'event_types': [], 'routes': [], 'mount_point': 'plugins.core.routes:register_routes', 'schedules': [{'name': 'echo', 'task': 'plugins.core.tasks:echo', 'every': 3600, 'cron': None}]}),
+    "eco-label": PluginManifest(**{'id': 'eco-label', 'event_types': ['ecolabel_view'], 'routes': [{'handler': 'plugins.ecolabel.ecolabel.views:router', 'path': None, 'method': 'GET', 'prefix': ''}, {'handler': 'plugins.ecolabel.ecolabel.hooks:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'mount_point': None, 'schedules': []}),
+    "eco-shift": PluginManifest(**{'id': 'eco-shift', 'event_types': ['ecs_shift'], 'routes': [{'handler': 'plugins.ecoshift.ecoshift.views:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'mount_point': None, 'schedules': [{'name': 'shift.autopilot', 'task': 'plugins.ecoshift.ecoshift.autopilot:run', 'every': 300, 'cron': None}]}),
+    "edge-router": PluginManifest(**{'id': 'edge-router', 'event_types': ['edge_route'], 'routes': [{'handler': 'plugins.edge_router.edge_router.views:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'mount_point': None, 'schedules': []}),
+    "green-dev": PluginManifest(**{'id': 'green-dev', 'event_types': ['dev_advice'], 'routes': [{'handler': 'plugins.greendev.greendev.views:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'mount_point': None, 'schedules': []}),
+    "iac-advisor": PluginManifest(**{'id': 'iac-advisor', 'event_types': ['iac_advice'], 'routes': [{'handler': 'plugins.iac_advisor.iac_advisor.views:router', 'path': None, 'method': 'GET', 'prefix': '/iac-advisor'}], 'mount_point': None, 'schedules': []}),
+    "offset-sync": PluginManifest(**{'id': 'offset-sync', 'event_types': ['offset_buy', 'saving'], 'routes': [], 'mount_point': None, 'schedules': []}),
+    "supply-pulse": PluginManifest(**{'id': 'supply-pulse', 'event_types': ['supplier_scan'], 'routes': [{'handler': 'plugins.pulse.pulse.views:router', 'path': None, 'method': 'GET', 'prefix': ''}], 'mount_point': None, 'schedules': [{'name': 'pulse.scan', 'task': 'plugins.pulse.pulse.scanner:nightly', 'every': None, 'cron': '0 2 * * *'}]}),
 }
 
-registry = REGISTRY
+registry = REGISTRY  # FastAPI alias
 __all__ = ['REGISTRY', 'registry']

--- a/backend/plugins/iac_advisor/iac_advisor/autopilot.py
+++ b/backend/plugins/iac_advisor/iac_advisor/autopilot.py
@@ -1,0 +1,10 @@
+from celery import Celery
+
+try:
+    from backend.worker.loader import app
+except Exception:  # pragma: no cover
+    app = Celery("carboncore")
+
+@app.task(name="iac_advisor.autopilot")
+def run():
+    return "ok"

--- a/backend/plugins/iac_advisor/iac_advisor/plan_parser.py
+++ b/backend/plugins/iac_advisor/iac_advisor/plan_parser.py
@@ -1,0 +1,13 @@
+def resources_from_tf(plan: dict):
+    """Return iterator of (address, instance_type, region)"""
+    for rc in plan.get("resource_changes", []):
+        if rc.get("type") != "aws_instance":
+            continue
+        after = (rc.get("change") or {}).get("after") or {}
+        az = after.get("availability_zone", "")
+        region = az[:-1] if len(az) > 0 else None
+        yield (
+            rc.get("address", "unknown"),
+            after.get("instance_type"),
+            region,
+        )

--- a/backend/plugins/iac_advisor/iac_advisor/views.py
+++ b/backend/plugins/iac_advisor/iac_advisor/views.py
@@ -1,0 +1,77 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import select
+from datetime import datetime
+from app.core.deps import get_db, get_project_from_token
+from app.models import Sku, SavingEvent
+from .plan_parser import resources_from_tf
+
+router = APIRouter()
+
+HIGH_INTENSITY = {"us-east-1", "ap-south-1"}  # example
+OLD_GEN = ("t1", "t2", "m1", "m2", "m3", "m4", "c3", "c4")
+
+def greener_alt(inst: str) -> str | None:
+    if inst.startswith(("t1", "t2")):
+        return inst.replace("t2", "t3", 1)
+    if inst.startswith(("m3", "m4")):
+        return inst.replace("m4", "m6g", 1)
+    if ".large" in inst and "g." not in inst:
+        fam, sz = inst.split(".")
+        return f"{fam}g.{sz}"
+    return None
+
+@router.post("/analyze")
+async def analyze(plan: dict,
+                  project=Depends(get_project_from_token),
+                  db: AsyncSession = Depends(get_db)):
+    if not plan:
+        raise HTTPException(400, "empty plan")
+
+    suggestions = []
+
+    for addr, inst, region in resources_from_tf(plan):
+        if not inst:
+            continue
+        heavy = inst.startswith(OLD_GEN) or region in HIGH_INTENSITY
+        if not heavy:
+            continue
+
+        alt = greener_alt(inst) or inst
+        sku_cur = await db.scalar(select(Sku).where(Sku.id == f"aws_{inst}"))
+        sku_alt = await db.scalar(select(Sku).where(Sku.id == f"aws_{alt}"))
+        if not sku_cur or not sku_alt:
+            continue
+
+        watts_diff = (sku_cur.vcpu * sku_cur.watts_per_cpu) - (sku_alt.vcpu * sku_alt.watts_per_cpu)
+        co2_day = round(max(watts_diff, 0) / 1_000 * 0.45 * 24, 2)
+        usd_day = round((sku_cur.price_per_hour - sku_alt.price_per_hour) * 24, 2)
+
+        suggestions.append(dict(resource=addr, current=inst, suggestion=alt,
+                                co2_saved_kg_per_day=co2_day, cost_saved_usd_per_day=usd_day))
+
+        db.add(SavingEvent(
+            project_id=project.id,
+            feature="iac-advisor",
+            event_type_id="iac_advice",
+            kwh=0,
+            co2=co2_day,
+            usd=usd_day,
+            created_at=datetime.utcnow(),
+        ))
+
+    await db.commit()
+    return {"suggestions": suggestions}
+
+@router.get("/recent")
+async def recent(limit: int = 20,
+                 project=Depends(get_project_from_token),
+                 db: AsyncSession = Depends(get_db)):
+    q = await db.execute(
+        select(SavingEvent)
+        .where(SavingEvent.project_id == project.id,
+               SavingEvent.event_type_id == "iac_advice")
+        .order_by(SavingEvent.created_at.desc())
+        .limit(limit)
+    )
+    return q.scalars().all()

--- a/backend/plugins/iac_advisor/manifest.py
+++ b/backend/plugins/iac_advisor/manifest.py
@@ -1,0 +1,12 @@
+from app.schemas.plugins import PluginManifest, Route
+
+manifest = PluginManifest(
+    id="iac-advisor",
+    event_types=["iac_advice"],
+    routes=[
+        Route(
+            handler="plugins.iac_advisor.iac_advisor.views:router",
+            prefix="/iac-advisor"
+        )
+    ],
+)

--- a/backend/plugins/iac_advisor/pyproject.toml
+++ b/backend/plugins/iac_advisor/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iac-advisor"
+version = "0.1.0"
+description = "IaC Advisor plugin"
+requires-python = ">=3.9"
+dependencies = ["fastapi", "sqlmodel"]

--- a/backend/plugins/iac_advisor/tests/test_parser.py
+++ b/backend/plugins/iac_advisor/tests/test_parser.py
@@ -1,0 +1,6 @@
+from plugins.iac_advisor.iac_advisor.plan_parser import resources_from_tf
+
+def test_parser():
+    plan = {"resource_changes": [{"type": "aws_instance", "change": {"after": {"instance_type": "m4.large", "availability_zone": "us-east-1a"}}}]}
+    items = list(resources_from_tf(plan))
+    assert items[0][1] == "m4.large"

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -13,3 +13,5 @@ BACKEND_URL=http://localhost:8000
 
 # OPTIONAL – expose to the browser with NEXT_PUBLIC_
 # NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+CARBONCORE_URL=http://localhost:8000
+NEXT_PUBLIC_PROJECT_TOKEN=demo-token

--- a/frontend/__tests__/advisor.spec.tsx
+++ b/frontend/__tests__/advisor.spec.tsx
@@ -1,0 +1,7 @@
+import { render } from "@testing-library/react";
+import { EventTable } from "@/components/EventTable";
+
+test("renders one row",()=>{
+  const { getByText } = render(<EventTable rows={[{id:1,project_id:"p",feature:"f",sku_id:"x",region:"AE",kwh:0,co2:1,usd:2,created_at:"2025-06-22"}]} />)
+  expect(getByText("p")).toBeTruthy()
+})

--- a/frontend/app/org/[orgId]/iac-advisor/page.tsx
+++ b/frontend/app/org/[orgId]/iac-advisor/page.tsx
@@ -1,0 +1,14 @@
+import { api } from "@/lib/api";
+import { EventTable } from "@/components/EventTable";
+
+export const revalidate = 60;
+
+export default async function Page() {
+  const rows = await api.recentAdvisor();
+  return (
+    <>
+      <h1 className="text-xl font-bold mb-4">IaC Advisor</h1>
+      <EventTable rows={rows} />
+    </>
+  );
+}

--- a/frontend/components/EventTable.tsx
+++ b/frontend/components/EventTable.tsx
@@ -1,0 +1,29 @@
+'use client';
+import type { SavingEvent } from '@/lib/types';
+
+export function EventTable({ rows }: { rows: SavingEvent[] }) {
+  return (
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="text-left text-white/60">
+          <th className="py-2">Project</th>
+          <th>Feature</th>
+          <th>CO₂</th>
+          <th>USD</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(r => (
+          <tr key={r.id} className="border-t border-white/10">
+            <td className="py-2">{r.project_id}</td>
+            <td>{r.feature}</td>
+            <td>{r.co2}</td>
+            <td>{r.usd}</td>
+            <td>{r.created_at.slice(0, 10)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/next.config.cjs
+++ b/frontend/next.config.cjs
@@ -28,6 +28,12 @@ const withProxyRewrites = {
       },
     ];
   },
+
+  async redirects() {
+    return [
+      { source: '/iac-advisor', destination: '/org/default/iac-advisor', permanent: false },
+    ];
+  },
 };
 
 module.exports = withProxyRewrites;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,3 +30,16 @@ export async function request<T>(
   if (res.status === 204) return {} as T;
   return res.json() as Promise<T>;
 }
+import type { SavingEvent } from './types';
+
+const CC_BASE = process.env.CARBONCORE_URL ?? '';
+function req<T>(path: string) {
+  return fetch(`${CC_BASE}${path}`, {
+    headers: { 'x-project-token': process.env.NEXT_PUBLIC_PROJECT_TOKEN ?? '' },
+    cache: 'no-store',
+  }).then(r => r.json() as Promise<T>);
+}
+
+export const api = {
+  recentAdvisor: (n = 20) => req<SavingEvent[]>(`/iac-advisor/recent?limit=${n}`),
+};

--- a/frontend/src/lib/nav.ts
+++ b/frontend/src/lib/nav.ts
@@ -6,7 +6,8 @@ export const NAV_BY_ROLE: Record<string, NavItem[]> = {
     { href: "/router", label: "Router", icon: "🗺", flag: "router" },
     { href: "/pulse", label: "Pulse", icon: "💓", flag: "pulse" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/scheduler", label: "Scheduler", icon: "⏱", flag: "scheduler" }
+    { href: "/scheduler", label: "Scheduler", icon: "⏱", flag: "scheduler" },
+    { href: "/iac-advisor", label: "IaC Advisor", icon: "🛠", flag: "iac-advisor" }
   ],
   finops: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,11 @@
+export interface SavingEvent {
+  id: number | string;
+  project_id: string;
+  feature: string;
+  sku_id?: string | null;
+  region?: string | null;
+  kwh: number;
+  co2: number;
+  usd: number;
+  created_at: string;
+}

--- a/plugins/iac-advisor/ui/Page.tsx
+++ b/plugins/iac-advisor/ui/Page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useEffect, useState } from 'react';
+import PageWrapper from '@/components/PageWrapper';
+
+export default function Page() {
+  const [rows, setRows] = useState<any[]>([]);
+  useEffect(() => {
+    fetch('/iac-advisor/recent')
+      .then(r => r.json())
+      .then(setRows);
+  }, []);
+  return (
+    <PageWrapper>
+      <h1 className="text-lg font-medium mb-4">IaC Advisor results</h1>
+      <pre className="bg-muted rounded p-4 text-xs">{JSON.stringify(rows, null, 2)}</pre>
+    </PageWrapper>
+  );
+}

--- a/plugins/iac-advisor/ui/index.ts
+++ b/plugins/iac-advisor/ui/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Page';

--- a/plugins/iac-advisor/ui/next.config.js
+++ b/plugins/iac-advisor/ui/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  output: 'standalone',
+  webpack: config => {
+    config.output.publicPath = 'auto';
+    return config;
+  },
+  experimental: { esmExternals: false },
+};


### PR DESCRIPTION
## Summary
- implement new IaC Advisor plugin with API routes
- expose helper to parse Terraform plans
- add Next.js page and navigation entry
- provide React table component and API client
- add GitHub Action to scan Terraform plans
- include unit and component tests

## Testing
- `PYTHONPATH=backend pytest backend/plugins/iac_advisor/tests/test_parser.py -q`
- `pnpm test` *(fails: Cannot find module '/workspace/carboncore/frontend/node-websocket')*

------
https://chatgpt.com/codex/tasks/task_e_685824644574832285eb3485560223a7