### PR TITLE
feat: finalize frontend integration

### DIFF
--- a/frontend/__tests__/EventTable.test.tsx
+++ b/frontend/__tests__/EventTable.test.tsx
@@ -24,8 +24,8 @@ describe("<EventTable />", () => {
 
     expect(utils.getByText(row.project_id)).toBeInTheDocument();
     expect(utils.getByText(row.feature)).toBeInTheDocument();
-    expect(utils.getByText("0.25")).toBeInTheDocument(); // USD
-    expect(utils.getByText("0.08")).toBeInTheDocument(); // CO₂
+    expect(utils.getByText(/\$0\.25/)).toBeInTheDocument();
+    expect(utils.getByText("0.08 kg")).toBeInTheDocument();
   });
 
   it("renders **no rows** when rows = []", () => {

--- a/frontend/app/api/org/[orgId]/flags/route.ts
+++ b/frontend/app/api/org/[orgId]/flags/route.ts
@@ -16,6 +16,8 @@ export async function GET(
     scheduler: true,
     budget: true,
     "iac-advisor": true,
+    greendev: true,
+    offsets: true,
   };
   return NextResponse.json(flags);
 }

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,9 +1,9 @@
-'use client'
-import { useEffect } from 'react'
-
+"use client";
 export default function Error({ error }: { error: Error }) {
-  useEffect(() => {
-    console.error(error)
-  }, [error])
-  return <div className="p-4 text-red-600">Something went wrong!</div>
+  return (
+    <div className="p-10 text-center">
+      <h1 className="text-red-600 text-xl font-bold mb-4">Something went wrong</h1>
+      <pre className="text-sm text-gray-500">{error.message}</pre>
+    </div>
+  );
 }

--- a/frontend/app/org/[orgId]/budget/page.tsx
+++ b/frontend/app/org/[orgId]/budget/page.tsx
@@ -1,7 +1,17 @@
 import BudgetView from "@/components/budget/BudgetView";
 import { request } from "@/lib/client";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function BudgetPage({ params:{orgId} }) {
-  const data = await request("/org/{orgId}/budget", "get",{orgId});
+export default function BudgetPage({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
+  const data = await request("/org/{orgId}/budget", "get", { orgId });
   return <BudgetView initial={data as any} orgId={orgId} />;
 }

--- a/frontend/app/org/[orgId]/dashboard/page.tsx
+++ b/frontend/app/org/[orgId]/dashboard/page.tsx
@@ -1,18 +1,23 @@
 import { fetchKpis } from '@/lib/kpi-api';
 import { getActiveOrgId } from '@/lib/org';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
 export const dynamic = 'force-dynamic';
 
-export default async function Dashboard({
-  params,
-}: {
-  params: { orgId: string };
-}) {
-  const orgId = getActiveOrgId(params.orgId);
-  if (!orgId) notFound();
-  const kpis = await fetchKpis(orgId);
+export default function DashboardPage({ params }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={params.orgId} />
+    </Suspense>
+  );
+}
 
+async function Content({ orgId }: { orgId: string }) {
+  const id = getActiveOrgId(orgId);
+  if (!id) notFound();
+  const kpis = await fetchKpis(id);
   return (
     <div className="space-y-6">
       <h1 className="font-bold text-lg">Dashboard</h1>

--- a/frontend/app/org/[orgId]/greendev/page.tsx
+++ b/frontend/app/org/[orgId]/greendev/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from 'next/navigation';
+import PageWrapper from '@/components/PageWrapper';
+import { Chat } from '@/components/greendev/Chat';
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
+
+export default function Page({ params: { orgId } }: { params: { orgId: string } }) {
+  if (!orgId) notFound();
+  return (
+    <Suspense fallback={<Loading />}>
+      <PageWrapper>
+        <h1 className="mb-6 text-2xl font-bold">GreenDev Bot 🤖</h1>
+        <Chat orgId={orgId} />
+      </PageWrapper>
+    </Suspense>
+  );
+}

--- a/frontend/app/org/[orgId]/iac-advisor/page.tsx
+++ b/frontend/app/org/[orgId]/iac-advisor/page.tsx
@@ -1,10 +1,20 @@
 import { api } from "@/lib/api";
 import { EventTable } from "@/components/EventTable";
+import { Suspense } from "react";
+import { Loading } from "@/components/Loading";
 
 
 export const revalidate = 60;
 
-export default async function Page() {
+export default function Page() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content />
+    </Suspense>
+  );
+}
+
+async function Content() {
   const rows = await api.recentAdvisor();
   return (
     <>

--- a/frontend/app/org/[orgId]/ledger/page.tsx
+++ b/frontend/app/org/[orgId]/ledger/page.tsx
@@ -1,11 +1,17 @@
 import { request } from "@/lib/client";
 import LedgerTable from "@/components/ledger/Table";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function LedgerPage({
-  params: { orgId },
-}: {
-  params: { orgId: string };
-}) {
+export default function LedgerPage({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
   const events = await request(
     "/org/{orgId}/ledger",
     "get",

--- a/frontend/app/org/[orgId]/offsets/page.tsx
+++ b/frontend/app/org/[orgId]/offsets/page.tsx
@@ -1,7 +1,32 @@
 import OffsetLedger from "@/components/offsets/OffsetLedger";
-import { request }  from "@/lib/client";
+import { NetZeroGauge } from "@/components/offsets/NetZeroGauge";
+import { ThresholdSlider } from "@/components/offsets/ThresholdSlider";
+import { api } from "@/lib/api";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function Offsets({ params:{orgId} }) {
-  const data = await request("/org/{orgId}/offsets", "get",{orgId});
-  return <OffsetLedger initial={data as any} orgId={orgId} />;
+export const revalidate = 60;
+
+export default function Page({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
+  const initial = await api.currentResidual(orgId);
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-6">Offsets & Net Zero</h1>
+
+      <div className="grid md:grid-cols-2 gap-6 mb-8">
+        <NetZeroGauge initial={initial.residual} />
+        <ThresholdSlider orgId={orgId} />
+      </div>
+
+      <OffsetLedger orgId={orgId} />
+    </>
+  );
 }

--- a/frontend/app/org/[orgId]/pulse/page.tsx
+++ b/frontend/app/org/[orgId]/pulse/page.tsx
@@ -1,7 +1,17 @@
 import PulseVendors from "@/components/pulse/VendorTable";
 import { request }  from "@/lib/client";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function Pulse({ params:{orgId} }) {
-  const vendors = await request("/org/{orgId}/vendors", "get",{orgId});
+export default function Pulse({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
+  const vendors = await request("/org/{orgId}/vendors", "get", { orgId });
   return <PulseVendors initial={vendors as any} orgId={orgId} />;
 }

--- a/frontend/app/org/[orgId]/reports/page.tsx
+++ b/frontend/app/org/[orgId]/reports/page.tsx
@@ -1,11 +1,15 @@
 import dynamic from "next/dynamic";
 const ReportWizard = dynamic(() => import("@/components/comply/ReportWizard").then(m => m.ReportWizard), { ssr: false });
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
 export default function ReportsPage() {
   return (
-    <section>
-      <h1 className="text-2xl font-bold mb-6">CarbonComply Report Wizard</h1>
-      <ReportWizard />
-    </section>
+    <Suspense fallback={<Loading />}>
+      <section>
+        <h1 className="text-2xl font-bold mb-6">CarbonComply Report Wizard</h1>
+        <ReportWizard />
+      </section>
+    </Suspense>
   );
 }

--- a/frontend/app/org/[orgId]/router/page.tsx
+++ b/frontend/app/org/[orgId]/router/page.tsx
@@ -1,7 +1,17 @@
 import RouterView from "@/components/router/RouterView";
 import { request }  from "@/lib/client";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function RouterPage({ params:{orgId} }) {
-  const data = await request("/org/{orgId}/router", "get",{orgId});
+export default function RouterPage({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
+  const data = await request("/org/{orgId}/router", "get", { orgId });
   return <RouterView initial={data} orgId={orgId} />;
 }

--- a/frontend/app/org/[orgId]/scheduler/page.tsx
+++ b/frontend/app/org/[orgId]/scheduler/page.tsx
@@ -1,7 +1,17 @@
 import SchedulerView from "@/components/scheduler/SchedulerView";
 import { request } from "@/lib/client";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function SchedulerPage({ params:{orgId} }) {
+export default function SchedulerPage({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
   const data = await request("/org/{orgId}/jobs", "get", { orgId });
   return <SchedulerView initial={data as any} orgId={orgId} />;
 }

--- a/frontend/app/org/[orgId]/settings/page.tsx
+++ b/frontend/app/org/[orgId]/settings/page.tsx
@@ -1,7 +1,17 @@
 import SettingsView from "@/components/settings/SettingsView";
 import { request } from "@/lib/client";
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
 
-export default async function SettingsPage({ params:{orgId} }) {
+export default function SettingsPage({ params: { orgId } }: { params: { orgId: string } }) {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Content orgId={orgId} />
+    </Suspense>
+  );
+}
+
+async function Content({ orgId }: { orgId: string }) {
   const data = await request("/org/{orgId}/settings", "get", { orgId });
   return <SettingsView initial={data as any} />;
 }

--- a/frontend/components/offsets/OffsetLedger.tsx
+++ b/frontend/components/offsets/OffsetLedger.tsx
@@ -4,13 +4,13 @@ import { OffsetPurchase } from "@/types/offset";
 import { useState, useEffect } from "react";
 
 export default function OffsetLedger({
-  initial,
+  initial = [],
   orgId,
 }: {
-  initial: OffsetPurchase[];
+  initial?: OffsetPurchase[];
   orgId: string;
 }) {
-  const [rows, setRows] = useState<OffsetPurchase[]>(initial ?? []);
+  const [rows, setRows] = useState<OffsetPurchase[]>(initial);
   const [evt] = useEventSource<OffsetPurchase>(
     `/api/proxy/org/${orgId}/offsets/stream`,
     { reconnect: true }

--- a/frontend/components/offsets/ThresholdSlider.tsx
+++ b/frontend/components/offsets/ThresholdSlider.tsx
@@ -1,36 +1,38 @@
 "use client";
-import { Slider } from "@/components/ui/Slider";
-import { withAsync } from "@/lib/withAsync";
-import { request } from "@/lib/client";
-import { useState } from "react";
+import { Slider } from "@headlessui/react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "react-hot-toast";
+import { apiFetch } from "@/lib/api/_fetch";
 
-export default function ThresholdSlider({
-  orgId,
-  initial,
-}: {
-  orgId: string;
-  initial: number;
-}) {
-  const [value, setValue] = useState(initial);
+export function ThresholdSlider({ orgId }: { orgId: string }) {
+  const q = useQuery({
+    queryKey: ["offset-threshold", orgId],
+    queryFn: () => apiFetch<number>(`/org/${orgId}/offset-threshold`),
+  });
 
-  const save = (v: number) =>
-    withAsync(
-      () => request("/org/{orgId}/offset-threshold", "patch", { orgId }, { value: v }),
-      "Threshold updated ✅",
-    );
+  const m = useMutation({
+    mutationFn: (v: number) =>
+      apiFetch(`/org/${orgId}/offset-threshold`, {
+        method: "PATCH",
+        body: JSON.stringify({ threshold: v }),
+      }),
+    onSuccess: () => toast.success("Threshold saved"),
+  });
+
+  if (!q.data) return null;
 
   return (
-    <div className="space-y-2">
-      <p className="text-sm">Purchase offsets when tCO₂e &gt; {value}</p>
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium">
+        Auto-purchase when residual ≥ {q.data} t CO₂
+      </label>
       <Slider
         min={0}
         max={5000}
         step={100}
-        defaultValue={[initial]}
-        onValueCommit={(val) => {
-          setValue(val[0]);
-          save(val[0]);
-        }}
+        value={q.data}
+        onChange={m.mutate}
+        className="w-full h-2 bg-gray-200 rounded"
       />
     </div>
   );

--- a/frontend/components/pulse/VendorModal.tsx
+++ b/frontend/components/pulse/VendorModal.tsx
@@ -4,8 +4,14 @@ import { Dialog } from "@headlessui/react";
 import { Line } from "react-chartjs-2";
 import { Button } from "@/components/ui/Button";
 import { toastSuccess, toastError } from "@/lib/toast";
+import { useQuery } from "@tanstack/react-query";
+import { vendorTrend } from "@/lib/vendor-api";
 
-export function VendorModal({ v, onClose }: { v: Vendor; onClose: () => void }) {
+export function VendorModal({ v, orgId, onClose }: { v: Vendor; orgId: string; onClose: () => void }) {
+  const { data: trend } = useQuery({
+    queryKey: ["vendor-trend", v.id],
+    queryFn: () => vendorTrend(orgId, v.id),
+  });
   async function handleEmail() {
     const r = await fetch(`/api/proxy/vendors/${v.id}/email`, { method: "POST" });
     r.ok ? toastSuccess("Remediation email sent") : toastError("Failed");
@@ -15,15 +21,12 @@ export function VendorModal({ v, onClose }: { v: Vendor; onClose: () => void }) 
     <Dialog open onClose={onClose} className="fixed inset-0 grid place-items-center">
       <Dialog.Panel className="bg-cc-base p-6 rounded max-w-lg w-full">
         <Dialog.Title className="text-lg font-bold mb-4">{v.name}</Dialog.Title>
-        {/* placeholder sparkline */}
         <Line
           data={{
             labels: Array(30).fill(""),
             datasets: [
               {
-                data: Array(30)
-                  .fill(0)
-                  .map(() => Math.random()),
+                data: trend ?? [],
                 borderColor: "#34d399"
               }
             ]

--- a/frontend/components/pulse/VendorTable.tsx
+++ b/frontend/components/pulse/VendorTable.tsx
@@ -55,7 +55,7 @@ export default function VendorTable({
           ))}
         </tbody>
       </table>
-      {modal && <VendorModal v={modal} onClose={() => setModal(null)} />}
+      {modal && <VendorModal v={modal} orgId={orgId} onClose={() => setModal(null)} />}
     </>
   );
 }

--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 import type { SavingEvent } from '@/lib/types';
+import { fmtKg, fmtUsd } from '@/lib/format';
 
 export function EventTable({ rows }: { rows: SavingEvent[] }) {
   return (
@@ -18,8 +19,8 @@ export function EventTable({ rows }: { rows: SavingEvent[] }) {
           <tr key={r.id} className="border-t border-white/10">
             <td className="py-2">{r.project_id}</td>
             <td>{r.feature}</td>
-            <td>{r.co2}</td>
-            <td>{r.usd}</td>
+            <td>{fmtKg.format(r.co2)} kg</td>
+            <td>{fmtUsd.format(r.usd)}</td>
             <td>{r.created_at.slice(0, 10)}</td>
           </tr>
         ))}

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -1,0 +1,3 @@
+export function Loading() {
+  return <div className="p-10 text-center text-gray-500">Loading…</div>;
+}

--- a/frontend/src/components/greendev/Chat.tsx
+++ b/frontend/src/components/greendev/Chat.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { FormEvent, useRef } from 'react';
+import { useChat } from '@/lib/useChat';
+import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
+
+export function Chat({ orgId }: { orgId: string }) {
+  const { ask, history, state } = useChat(orgId);
+  const input = useRef<HTMLInputElement>(null);
+
+  const onSend = async (e: FormEvent) => {
+    e.preventDefault();
+    const q = input.current!.value.trim();
+    if (!q) return;
+    await ask(q);
+    input.current!.value = '';
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex-1 overflow-y-auto rounded border p-4 h-[50vh]">
+        {history.map((m) => (
+          <p key={m.id} className={m.role === 'bot' ? 'text-green-700' : ''}>
+            <strong>{m.role === 'bot' ? 'Bot:' : 'You:'}</strong> {m.content}
+          </p>
+        ))}
+        {state === 'loading' && <p className="italic text-gray-500">…thinking</p>}
+      </div>
+
+      <form onSubmit={onSend} className="flex gap-2">
+        <input
+          ref={input}
+          type="text"
+          placeholder="Ask how to reduce CO₂ …"
+          className="flex-1 rounded border px-3 py-2"
+        />
+        <button className="rounded bg-emerald-600 px-4 py-2 text-white">
+          <PaperAirplaneIcon className="h-5 w-5 -rotate-45" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -42,4 +42,5 @@ function req<T>(path: string) {
 
 export const api = {
   recentAdvisor: (n = 20) => req<SavingEvent[]>(`/iac-advisor/recent?limit=${n}`),
+  currentResidual: (orgId: string) => req<{ residual: number }>(`/org/${orgId}/offsets/residual`),
 };

--- a/frontend/src/lib/api/_fetch.ts
+++ b/frontend/src/lib/api/_fetch.ts
@@ -1,0 +1,5 @@
+import { request } from '../request';
+
+export function apiFetch<T>(path: string, init?: RequestInit) {
+  return request<T>(path, init);
+}

--- a/frontend/src/lib/api/greendev.ts
+++ b/frontend/src/lib/api/greendev.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { apiFetch } from './_fetch';
+
+const Message = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'bot']),
+  content: z.string(),
+  created_at: z.string(),
+});
+
+export type Message = z.infer<typeof Message>;
+
+export async function askGreenDev(
+  orgId: string,
+  question: string,
+  context?: string[],
+): Promise<Message[]> {
+  return apiFetch(`/org/${orgId}/greendev/chat`, {
+    method: 'POST',
+    body: JSON.stringify({ question, context }),
+  }).then((r) => Message.array().parse(r as any));
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,6 @@
+export const fmtUsd = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+});
+export const fmtKg = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });

--- a/frontend/src/lib/nav.ts
+++ b/frontend/src/lib/nav.ts
@@ -7,7 +7,8 @@ export const NAV_BY_ROLE: Record<string, NavItem[]> = {
     { href: "/pulse", label: "Pulse", icon: "💓", flag: "pulse" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
     { href: "/scheduler", label: "Scheduler", icon: "⏱", flag: "scheduler" },
-    { href: "/iac-advisor", label: "IaC Advisor", icon: "🛠", flag: "iac-advisor" }
+    { href: "/iac-advisor", label: "IaC Advisor", icon: "🛠", flag: "iac-advisor" },
+    { href: "/greendev", label: "GreenDev Bot", icon: "🤖", flag: "greendev" }
   ],
   finops: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
@@ -17,7 +18,8 @@ export const NAV_BY_ROLE: Record<string, NavItem[]> = {
   sustainability: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/reports", label: "Reports", icon: "📄" }
+    { href: "/reports", label: "Reports", icon: "📄" },
+    { href: "/offsets", label: "Offsets", icon: "🌳" }
   ],
   admin: [{ href: "/settings", label: "Settings", icon: "⚙️" }]
 } as const;

--- a/frontend/src/lib/useChat.ts
+++ b/frontend/src/lib/useChat.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import type { Message } from './api/greendev';
+import { askGreenDev } from './api/greendev';
+
+export function useChat(orgId: string) {
+  const qc = useQueryClient();
+  const [history, setHistory] = useState<Message[]>([]);
+  const mutation = useMutation({
+    mutationFn: (question: string) =>
+      askGreenDev(orgId, question, history.map((h) => h.id)),
+    onSuccess: (msgs) => setHistory(msgs),
+  });
+
+  return {
+    history,
+    ask: mutation.mutateAsync,
+    state: mutation.status,
+  };
+}

--- a/frontend/src/lib/vendor-api.ts
+++ b/frontend/src/lib/vendor-api.ts
@@ -9,3 +9,7 @@ export async function fetchVendors(): Promise<Vendor[]> {
 export async function sendRemediationEmail(id: string) {
   await request(`/vendors/${id}/email`, "post", { id } as any);
 }
+
+export async function vendorTrend(orgId: string, vendorId: string) {
+  return request(`/org/${orgId}/vendors/${vendorId}/trend?days=30`, 'get');
+}

--- a/package.json
+++ b/package.json
@@ -2,5 +2,10 @@
 	"devDependencies": {
 		"@openapitools/openapi-generator-cli": "^2.20.2"
 	},
-	"packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
+	"packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81",
+	"dependencies": {
+		"@headlessui/react": "^2.2.4",
+		"@heroicons/react": "^2.2.0",
+		"@tanstack/react-query-devtools": "^5.81.2"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,17 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  '@headlessui/react':
+    specifier: ^2.2.4
+    version: 2.2.4(react-dom@19.1.0)(react@19.1.0)
+  '@heroicons/react':
+    specifier: ^2.2.0
+    version: 2.2.0(react@19.1.0)
+  '@tanstack/react-query-devtools':
+    specifier: ^5.81.2
+    version: 5.81.2(@tanstack/react-query@5.81.2)(react@19.1.0)
+
 devDependencies:
   '@openapitools/openapi-generator-cli':
     specifier: ^2.20.2
@@ -15,6 +26,71 @@ packages:
     resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
     dev: true
+
+  /@floating-ui/core@1.7.1:
+    resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
+    dependencies:
+      '@floating-ui/utils': 0.2.9
+    dev: false
+
+  /@floating-ui/dom@1.7.1:
+    resolution: {integrity: sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==}
+    dependencies:
+      '@floating-ui/core': 1.7.1
+      '@floating-ui/utils': 0.2.9
+    dev: false
+
+  /@floating-ui/react-dom@2.1.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.7.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@floating-ui/react@0.26.28(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 2.1.3(react-dom@19.1.0)(react@19.1.0)
+      '@floating-ui/utils': 0.2.9
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tabbable: 6.2.0
+    dev: false
+
+  /@floating-ui/utils@0.2.9:
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+    dev: false
+
+  /@headlessui/react@2.2.4(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-lz+OGcAH1dK93rgSMzXmm1qKOJkBUqZf1L4M8TWLNplftQD3IkoEDdUFNfAn4ylsN6WOTVtWaLmvmaHOUk1dTA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/focus': 3.20.5(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/interactions': 3.25.3(react-dom@19.1.0)(react@19.1.0)
+      '@tanstack/react-virtual': 3.13.10(react-dom@19.1.0)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      use-sync-external-store: 1.5.0(react@19.1.0)
+    dev: false
+
+  /@heroicons/react@2.2.0(react@19.1.0):
+    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
+    peerDependencies:
+      react: '>= 16 || ^19.0.0-rc'
+    dependencies:
+      react: 19.1.0
+    dev: false
 
   /@lukeed/csprng@1.1.0:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -141,6 +217,134 @@ packages:
       - encoding
       - supports-color
     dev: true
+
+  /@react-aria/focus@3.20.5(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-JpFtXmWQ0Oca7FcvkqgjSyo6xEP7v3oQOLUId6o0xTvm4AD5W0mU2r3lYrbhsJ+XxdUUX4AVR5473sZZ85kU4A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@19.1.0)(react@19.1.0)
+      '@react-aria/utils': 3.29.1(react-dom@19.1.0)(react@19.1.0)
+      '@react-types/shared': 3.30.0(react@19.1.0)
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@react-aria/interactions@3.25.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-J1bhlrNtjPS/fe5uJQ+0c7/jiXniwa4RQlP+Emjfc/iuqpW2RhbF9ou5vROcLzWIyaW8tVMZ468J68rAs/aZ5A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@19.1.0)
+      '@react-aria/utils': 3.29.1(react-dom@19.1.0)(react@19.1.0)
+      '@react-stately/flags': 3.1.2
+      '@react-types/shared': 3.30.0(react@19.1.0)
+      '@swc/helpers': 0.5.17
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@react-aria/ssr@3.9.9(react@19.1.0):
+    resolution: {integrity: sha512-2P5thfjfPy/np18e5wD4WPt8ydNXhij1jwA8oehxZTFqlgVMGXzcWKxTb4RtJrLFsqPO7RUQTiY8QJk0M4Vy2g==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 19.1.0
+    dev: false
+
+  /@react-aria/utils@3.29.1(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-yXMFVJ73rbQ/yYE/49n5Uidjw7kh192WNN9PNQGV0Xoc7EJUlSOxqhnpHmYTyO0EotJ8fdM1fMH8durHjUSI8g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@19.1.0)
+      '@react-stately/flags': 3.1.2
+      '@react-stately/utils': 3.10.7(react@19.1.0)
+      '@react-types/shared': 3.30.0(react@19.1.0)
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@react-stately/flags@3.1.2:
+    resolution: {integrity: sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==}
+    dependencies:
+      '@swc/helpers': 0.5.17
+    dev: false
+
+  /@react-stately/utils@3.10.7(react@19.1.0):
+    resolution: {integrity: sha512-cWvjGAocvy4abO9zbr6PW6taHgF24Mwy/LbQ4TC4Aq3tKdKDntxyD+sh7AkSRfJRT2ccMVaHVv2+FfHThd3PKQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 19.1.0
+    dev: false
+
+  /@react-types/shared@3.30.0(react@19.1.0):
+    resolution: {integrity: sha512-COIazDAx1ncDg046cTJ8SFYsX8aS3lB/08LDnbkH/SkdYrFPWDlXMrO/sUam8j1WWM+PJ+4d1mj7tODIKNiFog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      react: 19.1.0
+    dev: false
+
+  /@swc/helpers@0.5.17:
+    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@tanstack/query-core@5.81.2:
+    resolution: {integrity: sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==}
+    dev: false
+
+  /@tanstack/query-devtools@5.81.2:
+    resolution: {integrity: sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==}
+    dev: false
+
+  /@tanstack/react-query-devtools@5.81.2(@tanstack/react-query@5.81.2)(react@19.1.0):
+    resolution: {integrity: sha512-TX0OQ4cbgX6z2uN8c9x0QUNbyePGyUGdcgrGnV6TYEJc7KPT8PqeASuzoA5NGw1CiMGvyFAkIGA2KipvhM9d1g==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.81.2
+      react: ^18 || ^19
+    dependencies:
+      '@tanstack/query-devtools': 5.81.2
+      '@tanstack/react-query': 5.81.2(react@19.1.0)
+      react: 19.1.0
+    dev: false
+
+  /@tanstack/react-query@5.81.2(react@19.1.0):
+    resolution: {integrity: sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==}
+    peerDependencies:
+      react: ^18 || ^19
+    dependencies:
+      '@tanstack/query-core': 5.81.2
+      react: 19.1.0
+    dev: false
+
+  /@tanstack/react-virtual@3.13.10(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-nvrzk4E9mWB4124YdJ7/yzwou7IfHxlSef6ugCFcBfRmsnsma3heciiiV97sBNxyc3VuwtZvmwXd0aB5BpucVw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.13.10
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@tanstack/virtual-core@3.13.10:
+    resolution: {integrity: sha512-sPEDhXREou5HyZYqSWIqdU580rsF6FGeN7vpzijmP3KTiOGjOMZASz4Y6+QKjiFQwhWrR58OP8izYaNGVxvViA==}
+    dev: false
 
   /@tokenizer/inflate@0.2.7:
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -290,6 +494,11 @@ packages:
     engines: {node: '>=0.8'}
     requiresBuild: true
     dev: true
+
+  /clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -905,6 +1114,20 @@ packages:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: true
 
+  /react-dom@19.1.0(react@19.1.0):
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+    peerDependencies:
+      react: ^19.1.0
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+    dev: false
+
+  /react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -956,6 +1179,10 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
+
+  /scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+    dev: false
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1043,6 +1270,10 @@ packages:
       has-flag: 4.0.0
     dev: true
 
+  /tabbable@6.2.0:
+    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+    dev: false
+
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
@@ -1077,7 +1308,6 @@ packages:
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-    dev: true
 
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -1100,6 +1330,14 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
     dev: true
+
+  /use-sync-external-store@1.5.0(react@19.1.0):
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 19.1.0
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
## Summary
- add GreenDev Bot chat feature
- enhance Offsets page with gauge and slider
- fetch real vendor trend data for Pulse modal
- unify number formatting utilities
- add global loading component and error page
- update feature flags and navigation
- wrap pages in Suspense for loading states
- ensure EventTable uses formatted numbers

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685885ef36048322b833ce185260777f