### PR TITLE
Frontend polish improvements

### DIFF
--- a/frontend/__tests__/EventTable.test.tsx
+++ b/frontend/__tests__/EventTable.test.tsx
@@ -1,5 +1,5 @@
 // __tests__/EventTable.test.tsx
-import { EventTable } from "@/components/EventTable";
+import { EventTable } from "@/components/advisor/EventTable";
 import { describe, expect, it } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 

--- a/frontend/__tests__/advisor.spec.tsx
+++ b/frontend/__tests__/advisor.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { EventTable } from "@/components/EventTable";
+import { EventTable } from "@/components/advisor/EventTable";
 
 test("renders one row",()=>{
   const { getByText } = render(<EventTable rows={[{id:1,project_id:"p",feature:"f",sku_id:"x",region:"AE",kwh:0,co2:1,usd:2,created_at:"2025-06-22"}]} />)

--- a/frontend/app/_admin/events/EventsClient.tsx
+++ b/frontend/app/_admin/events/EventsClient.tsx
@@ -48,7 +48,7 @@ export default function EventsClient() {
           items={items}
           rowRenderer={(ev: any) => (
             <div
-              className="grid grid-cols-[160px_100px_120px_1fr] gap-2 text-sm hover:bg-muted/40 cursor-pointer"
+              className="hover:bg-muted/40 grid cursor-pointer grid-cols-[160px_100px_120px_1fr] gap-2 text-sm"
               onClick={() => router.push(`/events/${ev.id}`)}
             >
               <span>{new Date(ev.ts).toLocaleString()}</span>
@@ -59,7 +59,7 @@ export default function EventsClient() {
           )}
           rowClassName={i => (i % 2 ? 'bg-muted/20' : '')}
         />
-        {isFetchingNextPage && <Loader2 className="animate-spin mx-auto my-4" />}
+        {isFetchingNextPage && <Loader2 className="mx-auto my-4 animate-spin" />}
         <button
           hidden
           ref={el => {

--- a/frontend/app/_admin/events/[eventId]/page.tsx
+++ b/frontend/app/_admin/events/[eventId]/page.tsx
@@ -21,21 +21,21 @@ export default async function EventDetail({ params: { eventId } }: { params: { e
   return (
     <div className="space-y-6">
       <header className="flex items-center justify-between">
-        <h1 className="font-bold text-lg">Event {eventId}</h1>
+        <h1 className="text-lg font-bold">Event {eventId}</h1>
         <Button formAction={replay}>Replay</Button>
       </header>
 
       <div className="tabs">
-        <input type="radio" id="raw" name="tab" defaultChecked className="hidden peer" />
+        <input type="radio" id="raw" name="tab" defaultChecked className="peer hidden" />
         <label htmlFor="raw" className="tab">Raw</label>
-        <input type="radio" id="diff" name="tab" className="hidden peer" />
+        <input type="radio" id="diff" name="tab" className="peer hidden" />
         <label htmlFor="diff" className="tab">Diff</label>
 
         <div className="pt-4">
-          <div className="peer-checked:block hidden" id="rawPane">
+          <div className="hidden peer-checked:block" id="rawPane">
             <JsonViewer src={(ev as any).payload} theme="monokai" enableClipboard={false} />
           </div>
-          <div className="peer-checked:block hidden" id="diffPane">
+          <div className="hidden peer-checked:block" id="diffPane">
             {prev ? <DiffViewer oldData={(prev as any).payload} newData={(ev as any).payload} /> : 'No previous event'}
           </div>
         </div>

--- a/frontend/app/_admin/jobs/Jobs.client.tsx
+++ b/frontend/app/_admin/jobs/Jobs.client.tsx
@@ -14,7 +14,7 @@ export default function JobsClient() {
   return (
     <div className="space-y-6">
       <header className="flex items-center justify-between">
-        <h1 className="font-bold text-lg">Jobs</h1>
+        <h1 className="text-lg font-bold">Jobs</h1>
         <Button size="sm" variant="outline" onClick={() => setRefresh((x) => !x)}>
           {refresh ? 'Stop auto refresh' : 'Refresh every 10s'}
         </Button>
@@ -35,7 +35,7 @@ function JobSection({ state }: { state: string }) {
 
   return (
     <div>
-      <h2 className="font-medium capitalize mb-2">{state}</h2>
+      <h2 className="mb-2 font-medium capitalize">{state}</h2>
       <table className="w-full text-sm">
         <tbody>
           {data.items.map((j) => (

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,9 +1,11 @@
 "use client";
-export default function Error({ error }: { error: Error }) {
+export default function GlobalError({ error }: { error: Error }) {
   return (
-    <div className="p-10 text-center">
-      <h1 className="text-red-600 text-xl font-bold mb-4">Something went wrong</h1>
-      <pre className="text-sm text-gray-500">{error.message}</pre>
-    </div>
+    <html>
+      <body className="p-6 text-red-700">
+        <h1 className="text-lg font-bold">Something went wrong 💥</h1>
+        <pre className="whitespace-pre-wrap">{error.message}</pre>
+      </body>
+    </html>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({ children }: { children:React.ReactNode }){
   return (
     <ClerkProvider>
       <html lang="en" className={inter.variable}>
-        <body className="antialiased bg-gray-50 text-gray-800">
+        <body className="bg-gray-50 text-gray-800 antialiased">
           <Providers>
             <Shell>{children}</Shell>
           </Providers>

--- a/frontend/app/org/[orgId]/dashboard/page.tsx
+++ b/frontend/app/org/[orgId]/dashboard/page.tsx
@@ -20,10 +20,10 @@ async function Content({ orgId }: { orgId: string }) {
   const kpis = await fetchKpis(id);
   return (
     <div className="space-y-6">
-      <h1 className="font-bold text-lg">Dashboard</h1>
+      <h1 className="text-lg font-bold">Dashboard</h1>
       <ul className="grid grid-cols-2 gap-4">
         {kpis.items.map((k: any) => (
-          <li key={k.name} className="border rounded p-4">
+          <li key={k.name} className="rounded border p-4">
             <p className="text-muted-foreground text-sm">{k.name}</p>
             <p className="text-2xl font-bold">{k.value}</p>
           </li>

--- a/frontend/app/org/[orgId]/dashboard/remainingBudget.tsx
+++ b/frontend/app/org/[orgId]/dashboard/remainingBudget.tsx
@@ -9,7 +9,7 @@ export function RemainingBudgetTile({ initial }: { initial: number }) {
   return (
     <div className={`rounded p-4 ${danger ? "bg-cc-red animate-pulse" : "bg-white/5"}`}>
       <p className="text-sm">Remaining budget</p>
-      <p className="text-2xl font-mono">{value.toFixed(0)} €</p>
+      <p className="font-mono text-2xl">{value.toFixed(0)} €</p>
     </div>
   );
 }

--- a/frontend/app/org/[orgId]/ecolabel/page.tsx
+++ b/frontend/app/org/[orgId]/ecolabel/page.tsx
@@ -1,0 +1,25 @@
+import { api } from "@/lib/api";
+import { AsyncStates } from "@/components/ui/AsyncStates";
+
+export default async function Page({ params:{orgId} }: { params: { orgId: string } }) {
+  const data = await api.getEcoLabelStats(orgId);
+  if (!data.length) return <AsyncStates state="empty" message="No page views yet." />;
+  return (
+    <>
+    <table className="w-full text-sm">
+      <thead><tr><th>Route</th><th className="text-right">Avg g CO₂</th><th>Views</th></tr></thead>
+      <tbody>
+        {data.map(d=>(
+          <tr key={d.route}>
+            <td>{d.route}</td><td className="text-right">{d.avg.toFixed(2)}</td><td>{d.views}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    <pre className="mt-6 rounded bg-stone-100 p-3 text-xs">
+{`<script src="${process.env.NEXT_PUBLIC_APP_URL}/widget/widget.js"
+        data-org="${orgId}"></script>`}
+    </pre>
+    </>
+  );
+}

--- a/frontend/app/org/[orgId]/greendev/page.tsx
+++ b/frontend/app/org/[orgId]/greendev/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import PageWrapper from '@/components/PageWrapper';
-import { Chat } from '@/components/greendev/Chat';
+import ChatWindow from '@/components/greendev/ChatWindow';
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
@@ -10,7 +10,9 @@ export default function Page({ params: { orgId } }: { params: { orgId: string } 
     <Suspense fallback={<Loading />}>
       <PageWrapper>
         <h1 className="mb-6 text-2xl font-bold">GreenDev Bot 🤖</h1>
-        <Chat orgId={orgId} />
+        <div className="h-[60vh] rounded border">
+          <ChatWindow />
+        </div>
       </PageWrapper>
     </Suspense>
   );

--- a/frontend/app/org/[orgId]/iac-advisor/page.tsx
+++ b/frontend/app/org/[orgId]/iac-advisor/page.tsx
@@ -1,25 +1,22 @@
-import { api } from "@/lib/api";
-import { EventTable } from "@/components/EventTable";
-import { Suspense } from "react";
-import { Loading } from "@/components/Loading";
-
-
-export const revalidate = 60;
+"use client";
+import EventTable from "@/components/advisor/EventTable";
+import { EventDetailDialog } from "@/components/advisor/EventDetailDialog";
+import { useState } from "react";
+import { AsyncStates } from "@/components/ui/AsyncStates";
+import { useAdvisorEvents } from "@/lib/useAdvisorEvents";
 
 export default function Page() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <Content />
-    </Suspense>
-  );
-}
+  const { data, error, isLoading } = useAdvisorEvents();
+  const [selected, setSelected] = useState<string | null>(null);
 
-async function Content() {
-  const rows = await api.recentAdvisor();
+  if (isLoading) return <AsyncStates state="loading" />;
+  if (error) return <AsyncStates state="error" error="Failed to load events." />;
+  if (!data?.length) return <AsyncStates state="empty" message="No advisor events yet." />;
+
   return (
     <>
-      <h1 className="text-xl font-bold mb-4">IaC Advisor</h1>
-      <EventTable rows={rows} />
+      <EventTable rows={data} onRowClick={(id)=>setSelected(id)} />
+      {selected && <EventDetailDialog id={selected} onClose={()=>setSelected(null)} />}
     </>
   );
 }

--- a/frontend/app/org/[orgId]/offsets/page.tsx
+++ b/frontend/app/org/[orgId]/offsets/page.tsx
@@ -19,9 +19,9 @@ async function Content({ orgId }: { orgId: string }) {
   const initial = await api.currentResidual(orgId);
   return (
     <>
-      <h1 className="text-2xl font-bold mb-6">Offsets & Net Zero</h1>
+      <h1 className="mb-6 text-2xl font-bold">Offsets & Net Zero</h1>
 
-      <div className="grid md:grid-cols-2 gap-6 mb-8">
+      <div className="mb-8 grid gap-6 md:grid-cols-2">
         <NetZeroGauge initial={initial.residual} />
         <ThresholdSlider orgId={orgId} />
       </div>

--- a/frontend/app/org/[orgId]/reports/page.tsx
+++ b/frontend/app/org/[orgId]/reports/page.tsx
@@ -7,7 +7,7 @@ export default function ReportsPage() {
   return (
     <Suspense fallback={<Loading />}>
       <section>
-        <h1 className="text-2xl font-bold mb-6">CarbonComply Report Wizard</h1>
+        <h1 className="mb-6 text-2xl font-bold">CarbonComply Report Wizard</h1>
         <ReportWizard />
       </section>
     </Suspense>

--- a/frontend/components/AlertBanner.tsx
+++ b/frontend/components/AlertBanner.tsx
@@ -5,7 +5,7 @@ export default function AlertBanner({ count }: { count: number }) {
   if (!count) return null;
   return (
     <Alert variant="destructive" className="mb-4">
-      <ExclamationTriangleIcon className="h-4 w-4" />
+      <ExclamationTriangleIcon className="size-4" />
       <AlertTitle>{count} unresolved alerts</AlertTitle>
       <AlertDescription>
         <a href="/alerts" className="underline">Review now →</a>

--- a/frontend/components/Loading2.tsx
+++ b/frontend/components/Loading2.tsx
@@ -1,5 +1,5 @@
 export default function Loading() {
   return (
-    <div className="animate-spin h-8 w-8 rounded-full border-4 border-gray-300 border-t-transparent mx-auto" />
+    <div className="mx-auto size-8 animate-spin rounded-full border-4 border-gray-300 border-t-transparent" />
   )
 }

--- a/frontend/components/advisor/EventDetailDialog.tsx
+++ b/frontend/components/advisor/EventDetailDialog.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import { useEffect, useState } from "react";
+import { AdvisorEvent, api } from "@/lib/api";
+
+export function EventDetailDialog({ id, onClose }: { id: string; onClose(): void }) {
+  const [evt, setEvt] = useState<AdvisorEvent | null>(null);
+  const [state, setState] = useState<"loading" | "error" | "ready">("loading");
+
+  useEffect(() => {
+    api.getAdvisorEvent(id)
+       .then(setEvt)
+       .then(() => setState("ready"))
+       .catch(() => setState("error"));
+  }, [id]);
+
+  return (
+    <Dialog open onClose={onClose} className="fixed inset-0 grid place-items-center bg-black/40">
+      <DialogPanel className="w-[34rem] rounded-md bg-white p-6 shadow-xl">
+        {state === "loading" && <p>Loading…</p>}
+        {state === "error"   && <p className="text-red-600">Couldn’t load event.</p>}
+        {state === "ready" && evt && (
+          <>
+            <h2 className="mb-4 text-lg font-medium">{evt.project} – {evt.feature}</h2>
+            <table className="w-full text-sm">
+              <tbody>
+                <tr><td>CO₂ saved</td><td>{evt.kg_co2.toFixed(2)} kg</td></tr>
+                <tr><td>USD saved</td><td>${evt.usd.toFixed(2)}</td></tr>
+                <tr><td>Commit SHA</td><td><code>{evt.commit.slice(0,7)}</code></td></tr>
+                <tr><td>Date</td><td>{new Date(evt.date).toLocaleString()}</td></tr>
+              </tbody>
+            </table>
+          </>
+        )}
+      </DialogPanel>
+    </Dialog>
+  );
+}

--- a/frontend/components/advisor/EventTable.tsx
+++ b/frontend/components/advisor/EventTable.tsx
@@ -1,9 +1,9 @@
 'use client';
 import type { SavingEvent } from '@/lib/types';
 
-export function EventTable({ rows }: { rows: SavingEvent[] }) {
+export function EventTable({ rows, onRowClick }: { rows: SavingEvent[]; onRowClick?: (id: string) => void }) {
   return (
-    <table className="w-full text-sm border-collapse">
+    <table className="w-full border-collapse text-sm">
       <thead>
         <tr className="text-left text-white/60">
           <th className="py-2">Project</th>
@@ -15,7 +15,11 @@ export function EventTable({ rows }: { rows: SavingEvent[] }) {
       </thead>
       <tbody>
         {rows.map(r => (
-          <tr key={r.id} className="border-t border-white/10">
+          <tr
+            key={r.id}
+            className="cursor-pointer border-t border-white/10 hover:bg-white/5"
+            onClick={() => onRowClick?.(r.id)}
+          >
             <td className="py-2">{r.project_id}</td>
             <td>{r.feature}</td>
             <td>{r.co2}</td>

--- a/frontend/components/budget/BudgetChart.tsx
+++ b/frontend/components/budget/BudgetChart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ReferenceLine } from "recharts";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ReferenceLine, Legend } from "recharts";
 import { BudgetLine } from "@/types/budget";
 import { useEventSource } from "@/lib/useEventSource";
 import { useEffect, useState } from "react";
@@ -28,6 +28,7 @@ export function BudgetChart({ initial }: { initial: BudgetLine }) {
       <XAxis dataKey="date" tick={{ fontSize: 12 }} />
       <YAxis tick={{ fontSize: 12 }} />
       <Tooltip />
+      <Legend />
       <Line type="monotone" dataKey="eur" stroke="#34d399" dot={false} name="Actual" />
       <Line
         type="monotone"

--- a/frontend/components/budget/BudgetSettingsModal.tsx
+++ b/frontend/components/budget/BudgetSettingsModal.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import { useState } from "react";
+import { api } from "@/lib/api";
+export function BudgetSettingsModal({ budget, onClose }:{budget:number; onClose():void}) {
+  const [value,setValue]=useState(budget);
+  return (
+    <Dialog open onClose={onClose} className="fixed inset-0 grid place-items-center bg-black/40">
+      <DialogPanel className="w-80 rounded bg-white p-6">
+        <h2 className="mb-3 font-medium">Edit carbon budget (t CO₂)</h2>
+        <input type="number" value={value} onChange={e=>setValue(+e.target.value)}
+               className="w-full rounded border px-2 py-1"/>
+        <button className="mt-4 rounded bg-emerald-600 px-4 py-1 text-white"
+                onClick={()=>api.patchBudget({budget:value}).then(onClose)}>
+          Save
+        </button>
+      </DialogPanel>
+    </Dialog>
+  );
+}

--- a/frontend/components/budget/BudgetView.tsx
+++ b/frontend/components/budget/BudgetView.tsx
@@ -4,6 +4,8 @@ import { BudgetLine } from "@/types/budget";
 import { useState, useEffect } from "react";
 import { BudgetChart } from "./BudgetChart";
 import { BudgetAlertToasts } from "./BudgetAlertToasts";
+import { BudgetSettingsModal } from "./BudgetSettingsModal";
+import { Cog6ToothIcon } from "@heroicons/react/24/outline";
 
 export default function BudgetView({
   initial,
@@ -13,6 +15,7 @@ export default function BudgetView({
   orgId: string;
 }) {
   const [data, setData] = useState(initial);
+  const [showModal, setShowModal] = useState(false);
   const [evt] = useEventSource<BudgetLine>(
     `/api/proxy/org/${orgId}/budget/stream`,
     { reconnect: true }
@@ -24,8 +27,17 @@ export default function BudgetView({
 
   return (
     <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Carbon Budget</h1>
+        <button onClick={() => setShowModal(true)}>
+          <Cog6ToothIcon className="size-5" />
+        </button>
+      </header>
       <BudgetChart initial={data} />
       <BudgetAlertToasts />
+      {showModal && (
+        <BudgetSettingsModal budget={data.budgetEur} onClose={() => setShowModal(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/components/comply/ProgressBar.tsx
+++ b/frontend/components/comply/ProgressBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 export function ProgressBar({ value }: { value: number }) {
   return (
-    <div className="w-full h-2 bg-white/10 rounded">
+    <div className="h-2 w-full rounded bg-white/10">
       <div className="h-full bg-green-600" style={{ width: `${value}%` }} />
     </div>
   );

--- a/frontend/components/comply/ReportWizard.tsx
+++ b/frontend/components/comply/ReportWizard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { generateReport, pollStatus } from "@/lib/reports-api";
+import { toastError } from "@/lib/toast";
 import { ProgressBar } from "./ProgressBar";
 import { Button } from "@/components/ui/Button";
 
@@ -15,16 +16,21 @@ export function ReportWizard() {
     const { jobId } = (await generateReport({ fy }) as any);
     setJobId(jobId);
     setStep(2);
-    const done = await pollStatus(jobId, (pct) => setProgress(pct));
-    setFiles(done.files);
-    setStep(3);
+    try {
+      const done = await pollStatus(jobId, (pct) => setProgress(pct));
+      setFiles(done.files);
+      setStep(3);
+    } catch {
+      setStep(1);
+      toastError("Report generation failed.");
+    }
   }
 
   return (
-    <div className="max-w-xl mx-auto">
+    <div className="mx-auto max-w-xl">
       {step === 1 && (
         <>
-          <h2 className="text-xl font-semibold mb-4">Step 1 · Choose fiscal year</h2>
+          <h2 className="mb-4 text-xl font-semibold">Step 1 · Choose fiscal year</h2>
           <select value={fy} onChange={(e) => setFY(e.target.value)} className="mb-4">
             <option value="">— select —</option>
             {['2023', '2024', '2025'].map((y) => (
@@ -39,29 +45,35 @@ export function ReportWizard() {
 
       {step === 2 && (
         <>
-          <h2 className="text-xl font-semibold mb-4">Step 2 · Generating…</h2>
+          <h2 className="mb-4 text-xl font-semibold">Step 2 · Generating…</h2>
           <ProgressBar value={progress} />
         </>
       )}
 
       {step === 3 && (
         <>
-          <h2 className="text-xl font-semibold mb-4">Step 3 · Download</h2>
+          <h2 className="mb-4 text-xl font-semibold">Step 3 · Download</h2>
           <ul className="space-y-2">
-            {files.map((f) => (
-              <li
-                key={f.fmt}
-                className="flex justify-between items-center bg-white/5 px-4 py-2 rounded"
-              >
-                <span>{f.fmt.toUpperCase()}</span>
-                <a href={f.url} download className="underline">
-                  Download
-                </a>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+          {files.map((f) => (
+            <li
+              key={f.fmt}
+              className="flex items-center justify-between rounded bg-white/5 px-4 py-2"
+            >
+              <span>{f.fmt.toUpperCase()}</span>
+              <a href={f.url} download className="underline">
+                Download
+              </a>
+            </li>
+          ))}
+        </ul>
+        <button
+          className="mt-6 rounded border px-4 py-1 text-sm"
+          onClick={() => setStep(1)}
+        >
+          Generate another report
+        </button>
+      </>
+    )}
     </div>
   );
 }

--- a/frontend/components/dashboard/GaugeCanvas.tsx
+++ b/frontend/components/dashboard/GaugeCanvas.tsx
@@ -19,7 +19,7 @@ export function GaugeCanvas({ value, dangerThreshold, unit }: { value: number; d
   return (
     <div className="w-24 text-center">
       <canvas ref={ref} width={100} height={60} />
-      <p className="text-xs mt-1">
+      <p className="mt-1 text-xs">
         {value.toFixed(1)} {unit}
       </p>
     </div>

--- a/frontend/components/greendev/Chat.tsx
+++ b/frontend/components/greendev/Chat.tsx
@@ -18,7 +18,7 @@ export function Chat({ orgId }: { orgId: string }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex-1 overflow-y-auto rounded border p-4 h-[50vh]">
+      <div className="h-[50vh] flex-1 overflow-y-auto rounded border p-4">
         {history.map((m) => (
           <p key={m.id} className={m.role === 'bot' ? 'text-green-700' : ''}>
             <strong>{m.role === 'bot' ? 'Bot:' : 'You:'}</strong> {m.content}
@@ -35,7 +35,7 @@ export function Chat({ orgId }: { orgId: string }) {
           className="flex-1 rounded border px-3 py-2"
         />
         <button className="rounded bg-emerald-600 px-4 py-2 text-white">
-          <PaperAirplaneIcon className="h-5 w-5 -rotate-45" />
+          <PaperAirplaneIcon className="size-5 -rotate-45" />
         </button>
       </form>
     </div>

--- a/frontend/components/greendev/ChatWindow.tsx
+++ b/frontend/components/greendev/ChatWindow.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useChat } from "@/lib/useChat";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export default function ChatWindow() {
+  const { messages, send } = useChat();
+  return (
+    <div className="flex h-full flex-col">
+      <div className="grow space-y-3 overflow-y-auto p-4">
+          {messages.map((m,i)=>(
+            <div key={i} className={`rounded p-2 ${m.role==="user"?"bg-sky-50":"bg-stone-100"}`}> 
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
+            </div>
+          ))}
+      </div>
+      <form onSubmit={e=>{e.preventDefault();send(e.currentTarget.q.value);e.currentTarget.reset();}}
+            className="flex gap-2 border-t p-2">
+        <input name="q" placeholder="Ask GreenDev…" className="grow rounded border px-2 py-1"/>
+        <button className="rounded bg-emerald-600 px-4 py-1 text-white">Send</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/ledger/EventRow.tsx
+++ b/frontend/components/ledger/EventRow.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 
 export function EventRow({ e }: { e: LedgerEvent }) {
   return (
-    <div className="grid grid-cols-[120px_1fr_80px_80px_80px] gap-4 py-2 border-b border-white/10" data-row>
+    <div className="grid grid-cols-[120px_1fr_80px_80px_80px] gap-4 border-b border-white/10 py-2" data-row>
       <div className="font-mono text-xs text-white/70">{format(new Date(e.ts), "yyyy-MM-dd HH:mm")}</div>
       <div>{e.service}@{e.region}</div>
       <div className="text-right">{e.kwh.toFixed(2)} kWh</div>

--- a/frontend/components/offsets/OffsetLedger.tsx
+++ b/frontend/components/offsets/OffsetLedger.tsx
@@ -21,7 +21,7 @@ export default function OffsetLedger({
   }, [evt]);
 
   return (
-    <table className="w-full text-sm border-collapse">
+    <table className="w-full border-collapse text-sm">
       <thead>
         <tr className="text-left text-white/60">
           <th className="py-2">Date</th>

--- a/frontend/components/offsets/OffsetLedgerTable.tsx
+++ b/frontend/components/offsets/OffsetLedgerTable.tsx
@@ -11,7 +11,7 @@ export function OffsetLedgerTable() {
   });
 
   return (
-    <table className="w-full text-sm border-collapse">
+    <table className="w-full border-collapse text-sm">
       <thead>
         <tr className="text-left text-white/60">
           <th className="py-2">Date</th>

--- a/frontend/components/offsets/ThresholdSlider.tsx
+++ b/frontend/components/offsets/ThresholdSlider.tsx
@@ -32,7 +32,7 @@ export function ThresholdSlider({ orgId }: { orgId: string }) {
         step={100}
         value={q.data}
         onChange={m.mutate}
-        className="w-full h-2 bg-gray-200 rounded"
+        className="h-2 w-full rounded bg-gray-200"
       />
     </div>
   );

--- a/frontend/components/org/OrgSwitcher.tsx
+++ b/frontend/components/org/OrgSwitcher.tsx
@@ -39,17 +39,17 @@ export function OrgSwitcher({ currentId }: { currentId: string }) {
 
   return (
     <Menu as="div" className="relative">
-      <Menu.Button className="px-3 py-1 rounded bg-white/10">
+      <Menu.Button className="rounded bg-white/10 px-3 py-1">
         {currentOrg}
       </Menu.Button>
 
-      <Menu.Items className="absolute right-0 mt-2 bg-cc-base
-                              border border-white/10 rounded max-h-60 overflow-y-auto">
+      <Menu.Items className="bg-cc-base absolute right-0 mt-2
+                              max-h-60 overflow-y-auto rounded border border-white/10">
         {orgs.map(o => (
           <Menu.Item key={o.id}>
             {({ active }) => (
               <button
-                className={`block w-full text-left px-4 py-2
+                className={`block w-full px-4 py-2 text-left
                             ${active ? "bg-white/10" : ""}`}
                 onClick={() => router.replace(newOrgPath(o.id))}
               >

--- a/frontend/components/pulse/VendorModal.tsx
+++ b/frontend/components/pulse/VendorModal.tsx
@@ -4,26 +4,25 @@ import { Dialog } from "@headlessui/react";
 import { Line } from "react-chartjs-2";
 import { Button } from "@/components/ui/Button";
 import { toastSuccess, toastError } from "@/lib/toast";
-import { useQuery } from "@tanstack/react-query";
+import useSWR from "swr";
 import { vendorTrend } from "@/lib/vendor-api";
 
 export function VendorModal({ v, orgId, onClose }: { v: Vendor; orgId: string; onClose: () => void }) {
-  const { data: trend } = useQuery({
-    queryKey: ["vendor-trend", v.id],
-    queryFn: () => vendorTrend(orgId, v.id),
-  });
+  const { data, error } = useSWR(`/vendors/${v.id}/trend`, () => vendorTrend(orgId, v.id));
+  const trend = data;
   async function handleEmail() {
+    if (!confirm("Send remediation email to vendor?")) return;
     const r = await fetch(`/api/proxy/vendors/${v.id}/email`, { method: "POST" });
     r.ok ? toastSuccess("Remediation email sent") : toastError("Failed");
   }
 
   return (
     <Dialog open onClose={onClose} className="fixed inset-0 grid place-items-center">
-      <Dialog.Panel className="bg-cc-base p-6 rounded max-w-lg w-full">
-        <Dialog.Title className="text-lg font-bold mb-4">{v.name}</Dialog.Title>
+      <Dialog.Panel className="bg-cc-base w-full max-w-lg rounded p-6">
+        <Dialog.Title className="mb-4 text-lg font-bold">{v.name}</Dialog.Title>
         <Line
           data={{
-            labels: Array(30).fill(""),
+            labels: (trend ?? []).map((_,i)=>String(i)),
             datasets: [
               {
                 data: trend ?? [],

--- a/frontend/components/pulse/VendorTable.tsx
+++ b/frontend/components/pulse/VendorTable.tsx
@@ -39,13 +39,13 @@ export default function VendorTable({
           {vendors.map((v) => (
             <tr
               key={v.id}
-              className="border-t border-white/10 hover:bg-white/5 cursor-pointer"
+              className="cursor-pointer border-t border-white/10 hover:bg-white/5"
               onClick={() => setModal(v)}
             >
-              <td className="py-2 flex items-center gap-2">
+              <td className="flex items-center gap-2 py-2">
                 {v.name}
                 {isBreach(v) && (
-                  <span className="px-2 rounded bg-cc-red text-xs">⚠ breach</span>
+                  <span className="bg-cc-red rounded px-2 text-xs">⚠ breach</span>
                 )}
               </td>
               <td>{new URL(v.endpoint).host}</td>

--- a/frontend/components/scheduler/GridIntensityOverlay.tsx
+++ b/frontend/components/scheduler/GridIntensityOverlay.tsx
@@ -1,0 +1,17 @@
+import { CalendarApi } from "@fullcalendar/core";
+import { useEffect } from "react";
+import { api } from "@/lib/api";
+
+export function useGridOverlay(cal: CalendarApi | null) {
+  useEffect(() => {
+    if (!cal) return;
+    api.getGridIntensity(cal.view.activeStart, cal.view.activeEnd)
+       .then(slots => {
+         cal.getEvents().forEach(e => {
+           const slot = slots.find(s => e.start! >= s.start && e.start! < s.end);
+           if (!slot) return;
+           e.setProp("classNames", slot.clean ? ["!bg-green-100"] : ["!bg-red-50"]);
+         });
+       });
+  }, [cal, cal?.view.activeStart.valueOf()]);
+}

--- a/frontend/components/scheduler/JobTooltip.tsx
+++ b/frontend/components/scheduler/JobTooltip.tsx
@@ -11,7 +11,7 @@ export function JobTooltip({ eventArg }: { eventArg: any }) {
         <div>{eventArg.timeText} • {eventArg.event.title}</div>
       </TooltipTrigger>
       {pct !== 0 && (
-        <TooltipContent className="bg-cc-base p-3 rounded text-sm">
+        <TooltipContent className="bg-cc-base rounded p-3 text-sm">
           {pct < 0 ? "Move here to cut " : "Moving adds "}
           {Math.abs(pct)} % CO₂
           {j.suggestedStart && (

--- a/frontend/components/settings/FeatureFlagsTable.tsx
+++ b/frontend/components/settings/FeatureFlagsTable.tsx
@@ -26,7 +26,7 @@ export function FeatureFlagsTable() {
   }
 
   return (
-    <table className="text-sm w-full">
+    <table className="w-full text-sm">
       <thead>
         <tr className="text-left text-white/60">
           <th className="py-2">Feature</th>

--- a/frontend/components/settings/SettingsView.tsx
+++ b/frontend/components/settings/SettingsView.tsx
@@ -2,23 +2,40 @@
 import { SlackForm } from "./SlackForm";
 import { WebhookTable } from "./WebhookTable";
 import { FeatureFlagsTable } from "./FeatureFlagsTable";
+import { useState } from "react";
+import { api } from "@/lib/api";
 
 export default function SettingsView({ initial }: { initial: { slack: string; hooks: any[] } }) {
   const { slack, hooks } = initial;
+  const [threshold, setThreshold] = useState(0);
+  const role = "developer";
   return (
     <section className="space-y-8">
       <h1 className="text-2xl font-bold">Settings</h1>
       <div>
-        <h2 className="font-semibold mb-2">Slack integration</h2>
+        <h2 className="mb-2 font-semibold">Slack integration</h2>
         <SlackForm initial={slack ?? ""} />
       </div>
       <div>
-        <h2 className="font-semibold mb-2">Webhooks</h2>
+        <h2 className="mb-2 font-semibold">Webhooks</h2>
         <WebhookTable initial={hooks} />
       </div>
       <div>
-        <h2 className="font-semibold mb-2">Feature Flags</h2>
+        <h2 className="mb-2 font-semibold">Feature Flags</h2>
         <FeatureFlagsTable />
+        <ul className="mt-4 text-sm">
+          {role === "developer" && (
+            <li className="flex items-center justify-between py-2">
+              <span>Vendor breach threshold (kg CO₂/1k)</span>
+              <input
+                type="number"
+                value={threshold}
+                onChange={e => { setThreshold(+e.target.value); api.patchVendorThreshold(+e.target.value); }}
+                className="w-24 rounded border px-2 py-1 text-right"
+              />
+            </li>
+          )}
+        </ul>
       </div>
     </section>
   );

--- a/frontend/components/settings/SlackForm.tsx
+++ b/frontend/components/settings/SlackForm.tsx
@@ -19,7 +19,7 @@ export function SlackForm({ initial }: { initial?: string }) {
   }
 
   return (
-    <div className="space-y-3 max-w-md">
+    <div className="max-w-md space-y-3">
       <Input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://hooks.slack.com/…" />
       <Button onClick={handleSave}>Save & Test</Button>
     </div>

--- a/frontend/components/settings/WebhookTable.tsx
+++ b/frontend/components/settings/WebhookTable.tsx
@@ -32,14 +32,14 @@ export function WebhookTable({ initial }: { initial?: Webhook[] }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2 max-w-md">
+      <div className="flex max-w-md gap-2">
         <Input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://example.com/hook" />
         <Button onClick={add}>Add</Button>
       </div>
       <ul className="space-y-2">
         {hooks.map((h) => (
-          <li key={h.id} className="flex justify-between bg-white/5 px-3 py-1 rounded">
-            <span className="truncate mr-2">{h.url}</span>
+          <li key={h.id} className="flex justify-between rounded bg-white/5 px-3 py-1">
+            <span className="mr-2 truncate">{h.url}</span>
             <Button variant="ghost" size="sm" onClick={() => remove(h.id)} {...({} as any)}>
               Remove
             </Button>

--- a/frontend/components/ui/AsyncStates.tsx
+++ b/frontend/components/ui/AsyncStates.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { ReactNode } from "react";
+
+type Props =
+  | { state: "loading" }
+  | { state: "error"; error: string }
+  | { state: "empty"; message: string }
+  | { state: "ready"; children: ReactNode };
+
+export function AsyncStates(props: Props) {
+  if (props.state === "loading") return <p className="text-sm text-gray-500">Loading…</p>;
+  if (props.state === "error")   return <p className="text-sm text-red-600">{props.error}</p>;
+  if (props.state === "empty")   return <p className="text-sm text-gray-400">{props.message}</p>;
+  return <>{props.children}</>;
+}

--- a/frontend/components/ui/Slider.tsx
+++ b/frontend/components/ui/Slider.tsx
@@ -11,13 +11,13 @@ export const Slider = forwardRef<
   return (
     <RadixSlider.Root
       ref={ref}
-      className="relative flex items-center select-none touch-none w-full h-5"
+      className="relative flex h-5 w-full touch-none select-none items-center"
       {...props}
     >
-      <RadixSlider.Track className="bg-white/20 relative grow rounded-full h-[3px]">
-        <RadixSlider.Range className="absolute bg-green-500 rounded-full h-full" />
+      <RadixSlider.Track className="relative h-[3px] grow rounded-full bg-white/20">
+        <RadixSlider.Range className="absolute h-full rounded-full bg-green-500" />
       </RadixSlider.Track>
-      <RadixSlider.Thumb className="block w-4 h-4 bg-green-500 rounded-full" />
+      <RadixSlider.Thumb className="block size-4 rounded-full bg-green-500" />
     </RadixSlider.Root>
   );
 });

--- a/frontend/components/ui/Switch.tsx
+++ b/frontend/components/ui/Switch.tsx
@@ -15,7 +15,7 @@ export const Switch = forwardRef<
     )}
     {...props}
   >
-    <SwitchPrimitives.Thumb className="pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0" />
+    <SwitchPrimitives.Thumb className="pointer-events-none block size-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0" />
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = "Switch";

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -5,3 +5,4 @@ export { cn }         from "./cn";
 export { default as Badge } from './badge';
 export { default as Checkbox } from './checkbox';
 export { Alert, AlertTitle, AlertDescription } from './alert';
+export { AsyncStates } from "./AsyncStates";

--- a/frontend/frontend/components/greendev/__tests__/ChatWindow.test.tsx
+++ b/frontend/frontend/components/greendev/__tests__/ChatWindow.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import ChatWindow from "../ChatWindow";
+import { describe, it, expect } from "vitest";
+
+// simple mock of useChat
+vi.mock("@/lib/useChat", () => ({
+  useChat: () => ({ messages: [], send: vi.fn() })
+}));
+
+describe("ChatWindow", () => {
+  it("renders input", () => {
+    render(<ChatWindow />);
+    expect(screen.getByPlaceholderText(/Ask GreenDev/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,10 +54,12 @@
     "react-dom": "18.3.1",
     "react-error-boundary": "4.1.2",
     "react-leaflet": "^5.0.0",
+    "react-markdown": "^10.1.0",
     "react-use": "^17.6.0",
     "react-virtualized": "^9.22.6",
     "react-window": "^1.8.11",
     "recharts": "^2.15.3",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react-leaflet:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.23)(react@18.3.1)
       react-use:
         specifier: ^17.6.0
         version: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -134,6 +137,9 @@ importers:
       recharts:
         specifier: ^2.15.3
         version: 2.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       sonner:
         specifier: ^2.0.5
         version: 2.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -227,7 +233,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.3)(typescript@5.5.4))(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.3)(typescript@5.5.4))(yaml@2.8.0)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1636,11 +1642,20 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/js-cookie@2.2.7':
     resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
@@ -1651,8 +1666,14 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.0.3':
     resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
@@ -1675,6 +1696,12 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -1737,6 +1764,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.34.1':
     resolution: {integrity: sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.9.0':
     resolution: {integrity: sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==}
@@ -2019,6 +2049,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2092,6 +2125,9 @@ packages:
   caniuse-lite@1.0.30001723:
     resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -2111,6 +2147,18 @@ packages:
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chart.js@4.5.0:
     resolution: {integrity: sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==}
@@ -2182,6 +2230,9 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -2348,6 +2399,9 @@ packages:
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+
   decode-uri-component@0.4.1:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
     engines: {node: '>=14.16'}
@@ -2384,6 +2438,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2500,6 +2557,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-next@15.3.4:
     resolution: {integrity: sha512-WqeumCq57QcTP2lYlV6BRUySfGiBYEXlQ1L0mQ+u4N4X4ZhUVSSQ52WtjqHv60pJ6dD7jn+YZc0d1/ZSsxccvg==}
@@ -2630,6 +2691,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2650,6 +2714,9 @@ packages:
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2861,12 +2928,21 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2918,6 +2994,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.4:
+    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
@@ -2928,6 +3007,12 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -2972,6 +3057,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
@@ -3005,6 +3093,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
@@ -3027,6 +3118,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3288,6 +3383,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3323,9 +3421,57 @@ packages:
   map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -3342,6 +3488,90 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3580,6 +3810,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -3739,6 +3972,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -3796,6 +4032,12 @@ packages:
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3904,6 +4146,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4095,6 +4349,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split-on-first@3.0.0:
     resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
     engines: {node: '>=12'}
@@ -4190,6 +4447,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -4216,6 +4476,12 @@ packages:
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  style-to-js@1.1.17:
+    resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
+
+  style-to-object@1.0.9:
+    resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -4343,6 +4609,12 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -4435,6 +4707,24 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -4499,6 +4789,12 @@ packages:
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vfile-message@4.0.2:
+    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
@@ -4712,6 +5008,9 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -5976,9 +6275,21 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/js-cookie@2.2.7': {}
 
@@ -5986,7 +6297,13 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/mdx@2.0.13': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.0.3':
     dependencies:
@@ -6014,6 +6331,10 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -6108,6 +6429,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.34.1
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.9.0':
     optional: true
@@ -6214,7 +6537,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.3)(typescript@5.5.4))(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.3)(typescript@5.5.4))(yaml@2.8.0)
     optional: true
 
   '@vitest/utils@3.2.4':
@@ -6386,6 +6709,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -6460,6 +6785,8 @@ snapshots:
 
   caniuse-lite@1.0.30001723: {}
 
+  ccount@2.0.1: {}
+
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -6481,6 +6808,14 @@ snapshots:
   chalk@5.2.0: {}
 
   chalk@5.4.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chart.js@4.5.0:
     dependencies:
@@ -6546,6 +6881,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
 
@@ -6680,6 +7017,10 @@ snapshots:
 
   decimal.js@10.5.0: {}
 
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decode-uri-component@0.4.1: {}
 
   deep-eql@5.0.2: {}
@@ -6709,6 +7050,10 @@ snapshots:
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -6906,6 +7251,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-next@15.3.4(eslint@9.29.0(jiti@2.4.2))(typescript@5.5.4):
     dependencies:
@@ -7114,6 +7461,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -7137,6 +7486,8 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expect-type@1.2.1: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -7347,11 +7698,37 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.17
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@4.0.3: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-url-attributes@3.0.1: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -7394,6 +7771,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.4: {}
+
   inline-style-prefixer@7.0.1:
     dependencies:
       css-in-js-utils: 3.1.0
@@ -7405,6 +7784,13 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-arguments@1.2.0:
     dependencies:
@@ -7459,6 +7845,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
@@ -7486,6 +7874,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@2.0.0: {}
 
   is-map@2.0.3: {}
@@ -7500,6 +7890,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7762,6 +8154,8 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -7790,7 +8184,162 @@ snapshots:
 
   map-or-similar@1.5.0: {}
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.0
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.0.14: {}
 
@@ -7803,6 +8352,197 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.1
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -8074,6 +8814,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -8204,6 +8954,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -8260,6 +9012,24 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   react-lifecycles-compat@3.0.4: {}
+
+  react-markdown@10.1.0(@types/react@18.3.23)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.23
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-remove-scroll-bar@2.3.8(@types/react@18.3.23)(react@18.3.1):
     dependencies:
@@ -8414,6 +9184,40 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -8637,6 +9441,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split-on-first@3.0.0: {}
 
   stable-hash@0.0.5: {}
@@ -8759,6 +9565,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8780,6 +9591,14 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  style-to-js@1.1.17:
+    dependencies:
+      style-to-object: 1.0.9
+
+  style-to-object@1.0.9:
+    dependencies:
+      inline-style-parser: 0.2.4
 
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:
@@ -8913,6 +9732,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-api-utils@2.1.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
@@ -9013,6 +9836,39 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
   universalify@0.2.0: {}
 
   universalify@2.0.1: {}
@@ -9094,6 +9950,16 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
+  vfile-message@4.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.2
+
   victory-vendor@36.9.2:
     dependencies:
       '@types/d3-array': 3.2.1
@@ -9147,7 +10013,7 @@ snapshots:
       lightningcss: 1.30.1
       yaml: 2.8.0
 
-  vitest@3.2.4(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.3)(typescript@5.5.4))(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@24.0.3)(typescript@5.5.4))(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -9173,6 +10039,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 24.0.3
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 26.1.0
@@ -9326,3 +10193,5 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   zod@3.23.8: {}
+
+  zwitch@2.0.4: {}

--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -4,7 +4,7 @@ import { fmtKg, fmtUsd } from '@/lib/format';
 
 export function EventTable({ rows }: { rows: SavingEvent[] }) {
   return (
-    <table className="w-full text-sm border-collapse">
+    <table className="w-full border-collapse text-sm">
       <thead>
         <tr className="text-left text-white/60">
           <th className="py-2">Project</th>

--- a/frontend/src/components/greendev/Chat.tsx
+++ b/frontend/src/components/greendev/Chat.tsx
@@ -18,7 +18,7 @@ export function Chat({ orgId }: { orgId: string }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex-1 overflow-y-auto rounded border p-4 h-[50vh]">
+      <div className="h-[50vh] flex-1 overflow-y-auto rounded border p-4">
         {history.map((m) => (
           <p key={m.id} className={m.role === 'bot' ? 'text-green-700' : ''}>
             <strong>{m.role === 'bot' ? 'Bot:' : 'You:'}</strong> {m.content}
@@ -35,7 +35,7 @@ export function Chat({ orgId }: { orgId: string }) {
           className="flex-1 rounded border px-3 py-2"
         />
         <button className="rounded bg-emerald-600 px-4 py-2 text-white">
-          <PaperAirplaneIcon className="h-5 w-5 -rotate-45" />
+          <PaperAirplaneIcon className="size-5 -rotate-45" />
         </button>
       </form>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,6 +31,15 @@ export async function request<T>(
   return res.json() as Promise<T>;
 }
 import type { SavingEvent } from './types';
+export interface AdvisorEvent {
+  id: string;
+  project: string;
+  feature: string;
+  kg_co2: number;
+  usd: number;
+  commit: string;
+  date: string;
+}
 
 const CC_BASE = process.env.CARBONCORE_URL ?? '';
 function req<T>(path: string) {
@@ -42,5 +51,15 @@ function req<T>(path: string) {
 
 export const api = {
   recentAdvisor: (n = 20) => req<SavingEvent[]>(`/iac-advisor/recent?limit=${n}`),
+  getAdvisorEvent: (id: string) => req<AdvisorEvent>(`/iac-advisor/event/${id}`),
+  patchBudget: (body: { budget: number }) => request(`/api/budget`, {
+    method: 'PATCH',
+    body: JSON.stringify(body)
+  }),
+  patchVendorThreshold: (value: number) => request(`/api/vendor-threshold`, {
+    method: 'PATCH',
+    body: JSON.stringify({ threshold: value })
+  }),
+  getEcoLabelStats: (orgId: string) => req<{ route: string; avg: number; views: number }[]>(`/org/${orgId}/ecolabel`),
   currentResidual: (orgId: string) => req<{ residual: number }>(`/org/${orgId}/offsets/residual`),
 };

--- a/frontend/src/lib/client.ts
+++ b/frontend/src/lib/client.ts
@@ -95,7 +95,7 @@ export async function request<
       return FIXTURES[key] as R;
     }
     // no fixture yet → avoid crashes
-    /* eslint-disable-next-line no-console */
+     
     console.warn("[API] missing fixture for", key);
     return {} as R;
   }

--- a/frontend/src/lib/debounce.ts
+++ b/frontend/src/lib/debounce.ts
@@ -1,0 +1,4 @@
+export function debounce<T extends unknown[]>(fn:(...a:T)=>void, ms=400){
+  let h:NodeJS.Timeout;
+  return (...args:T)=>{ clearTimeout(h); h=setTimeout(()=>fn(...args),ms); };
+}

--- a/frontend/src/lib/nav.ts
+++ b/frontend/src/lib/nav.ts
@@ -13,12 +13,14 @@ export const NAV_BY_ROLE: Record<string, NavItem[]> = {
   finops: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/budget", label: "Budget", icon: "💶", flag: "budget" }
+    { href: "/budget", label: "Budget", icon: "💶", flag: "budget" },
+    { href: "/offsets", label: "Offsets", icon: "🌿" }
   ],
   sustainability: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
     { href: "/reports", label: "Reports", icon: "📄" },
+    { href: "/ecolabel", label: "EcoLabel", icon: "🏷" },
     { href: "/offsets", label: "Offsets", icon: "🌳" }
   ],
   admin: [{ href: "/settings", label: "Settings", icon: "⚙️" }]

--- a/frontend/src/lib/reports-api.ts
+++ b/frontend/src/lib/reports-api.ts
@@ -19,5 +19,9 @@ export async function pollStatus(jobId: string, onProgress: (pct: number) => voi
         reject(new Error("Report error"));
       }
     };
+    es.onerror = () => {
+      es.close();
+      reject(new Error("Report error"));
+    };
   });
 }

--- a/frontend/src/lib/useAdvisorEvents.ts
+++ b/frontend/src/lib/useAdvisorEvents.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from './api';
+
+export function useAdvisorEvents() {
+  return useQuery({
+    queryKey: ['advisor-events'],
+    queryFn: () => api.recentAdvisor(),
+  });
+}

--- a/frontend/src/lib/usePolicyWeight.ts
+++ b/frontend/src/lib/usePolicyWeight.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchPolicy } from './policy-api';
+
+export function usePolicyWeight() {
+  return useQuery({
+    queryKey: ['policy-weight'],
+    queryFn: fetchPolicy,
+    select: (d) => d.weight,
+    staleTime: 60_000,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ packages:
       '@floating-ui/react': 0.26.28(react-dom@19.1.0)(react@19.1.0)
       '@react-aria/focus': 3.20.5(react-dom@19.1.0)(react@19.1.0)
       '@react-aria/interactions': 3.25.3(react-dom@19.1.0)(react@19.1.0)
-      '@tanstack/react-virtual': 3.13.10(react-dom@19.1.0)(react@19.1.0)
+      '@tanstack/react-virtual': 3.13.11(react-dom@19.1.0)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.5.0(react@19.1.0)
@@ -331,19 +331,19 @@ packages:
       react: 19.1.0
     dev: false
 
-  /@tanstack/react-virtual@3.13.10(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-nvrzk4E9mWB4124YdJ7/yzwou7IfHxlSef6ugCFcBfRmsnsma3heciiiV97sBNxyc3VuwtZvmwXd0aB5BpucVw==}
+  /@tanstack/react-virtual@3.13.11(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-u5EaOSJOq08T9NXFuDopMdxZBNDFuEMohIFFU45fBYDXXh9SjYdbpNq1OLFSOpQnDRPjqgmY96ipZTkzom9t9Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
-      '@tanstack/virtual-core': 3.13.10
+      '@tanstack/virtual-core': 3.13.11
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
-  /@tanstack/virtual-core@3.13.10:
-    resolution: {integrity: sha512-sPEDhXREou5HyZYqSWIqdU580rsF6FGeN7vpzijmP3KTiOGjOMZASz4Y6+QKjiFQwhWrR58OP8izYaNGVxvViA==}
+  /@tanstack/virtual-core@3.13.11:
+    resolution: {integrity: sha512-ORL6UyuZJ0D9X33LDR4TcgcM+K2YiS2j4xbvH1vnhhObwR1Z4dKwPTL/c0kj2Yeb4Yp2lBv1wpyVaqlohk8zpg==}
     dev: false
 
   /@tokenizer/inflate@0.2.7:


### PR DESCRIPTION
## Summary
- add AsyncStates wrapper
- implement IaC Advisor details dialog and update listing page
- overlay grid intensity on scheduler calendar
- add budget settings modal and chart legend
- create EcoLabel analytics page and update navigation

## Testing
- `pnpm lint` *(fails: @typescript-eslint rules missing)*
- `pnpm test` *(fails: module resolution errors)*
- `pnpm exec tsc --noEmit` *(fails: several type errors)*
- `pnpm dlx @axe-core/cli --exit` *(fails: chromedriver ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6859cde6fbf48322ae729f5c783eb9ad